### PR TITLE
HTTP support for S3 Compatible Storage

### DIFF
--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -299,6 +299,39 @@ def build_folder_params(path):
     return {'prefix': path.path, 'delimiter': '/'}
 
 
+class TestProviderConstruction:
+
+    def test_https(self, auth, credentials, settings):
+        provider = S3CompatProvider(auth, {'host': 'securehost',
+                                           'access_key': 'a',
+                                           'secret_key': 's'}, settings)
+        assert provider.connection.is_secure
+        assert provider.connection.host == 'securehost'
+        assert provider.connection.port == 443
+
+        provider = S3CompatProvider(auth, {'host': 'securehost:443',
+                                           'access_key': 'a',
+                                           'secret_key': 's'}, settings)
+        assert provider.connection.is_secure
+        assert provider.connection.host == 'securehost'
+        assert provider.connection.port == 443
+
+    def test_http(self, auth, credentials, settings):
+        provider = S3CompatProvider(auth, {'host': 'normalhost:80',
+                                           'access_key': 'a',
+                                           'secret_key': 's'}, settings)
+        assert not provider.connection.is_secure
+        assert provider.connection.host == 'normalhost'
+        assert provider.connection.port == 80
+
+        provider = S3CompatProvider(auth, {'host': 'normalhost:8080',
+                                           'access_key': 'a',
+                                           'secret_key': 's'}, settings)
+        assert not provider.connection.is_secure
+        assert provider.connection.host == 'normalhost'
+        assert provider.connection.port == 8080
+
+
 class TestValidatePath:
 
     @pytest.mark.asyncio

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -2,6 +2,7 @@ import os
 import hashlib
 import functools
 from urllib import parse
+import re
 
 import xmltodict
 
@@ -84,17 +85,17 @@ class S3CompatProvider(provider.BaseProvider):
         super().__init__(auth, credentials, settings)
 
         host = credentials['host']
-        if host.endswith(':80'):
-            self.connection = S3CompatConnection(credentials['access_key'],
-                                                 credentials['secret_key'],
-                                                 calling_format=OrdinaryCallingFormat(),
-                                                 host=host.split(':')[0],
-                                                 is_secure=False)
-        else:
-            self.connection = S3CompatConnection(credentials['access_key'],
-                                                 credentials['secret_key'],
-                                                 calling_format=OrdinaryCallingFormat(),
-                                                 host=host)
+        port = 443
+        m = re.match(r'^(.+)\:([0-9]+)$', host)
+        if m is not None:
+            host = m.group(1)
+            port = int(m.group(2))
+        self.connection = S3CompatConnection(credentials['access_key'],
+                                             credentials['secret_key'],
+                                             calling_format=OrdinaryCallingFormat(),
+                                             host=host,
+                                             port=port,
+                                             is_secure=port == 443)
         self.bucket = self.connection.get_bucket(settings['bucket'], validate=False)
         self.encrypt_uploads = self.settings.get('encrypt_uploads', False)
 

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -83,10 +83,18 @@ class S3CompatProvider(provider.BaseProvider):
         """
         super().__init__(auth, credentials, settings)
 
-        self.connection = S3CompatConnection(credentials['access_key'],
-                                             credentials['secret_key'],
-                                             calling_format=OrdinaryCallingFormat(),
-                                             host=credentials['host'])
+        host = credentials['host']
+        if host.endswith(':80'):
+            self.connection = S3CompatConnection(credentials['access_key'],
+                                                 credentials['secret_key'],
+                                                 calling_format=OrdinaryCallingFormat(),
+                                                 host=host.split(':')[0],
+                                                 is_secure=False)
+        else:
+            self.connection = S3CompatConnection(credentials['access_key'],
+                                                 credentials['secret_key'],
+                                                 calling_format=OrdinaryCallingFormat(),
+                                                 host=host)
         self.bucket = self.connection.get_bucket(settings['bucket'], validate=False)
         self.encrypt_uploads = self.settings.get('encrypt_uploads', False)
 


### PR DESCRIPTION

## Ticket

GRDM-11023

## Purpose

To use S3-like Storage which has no HTTPS endpoints, add HTTP support for S3 Compatible Storage.

## Changes

* Add Port option to host parameter of a provider credential

## Side effects

None

## QA Notes

None

## Deployment Notes

None
