### PR TITLE
Feature/quota restrict

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -610,7 +610,7 @@ class TestMetadata:
     async def test_must_not_be_none(self, provider):
         path = WaterButlerPath('/Goats', _ids=(provider.folder, None))
 
-        with pytest.raises(exceptions.NotFoundError) as e:
+        with pytest.raises(exceptions.MetadataError) as e:
             await provider.metadata(path)
 
         assert e.value.code == 404
@@ -745,7 +745,7 @@ class TestMetadata:
     async def test_metadata_missing(self, provider):
         path = WaterButlerPath('/Something', _ids=(provider.folder, None))
 
-        with pytest.raises(exceptions.NotFoundError) as exc:
+        with pytest.raises(exceptions.MetadataError) as exc:
             await provider.metadata(path)
 
         assert exc.value.code == HTTPStatus.NOT_FOUND

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 import aiohttpretty
 
+from waterbutler import settings as wb_settings
 from waterbutler.core import metadata
 from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
@@ -672,6 +673,11 @@ class TestUploads:
         provider, inner_provider = provider_and_mock_one
         inner_provider.metadata = utils.MockCoroutine(return_value=utils.MockFileMetadata())
 
+        url, _, params = provider.build_signed_url(
+            'GET', '{}/api/v1/project/foo/creator_quota/'.format(wb_settings.OSF_URL))
+        quota = {'max': 10000, 'used': 0}
+        aiohttpretty.register_json_uri('GET', url, body=quota, params=params)
+
         res, created = await provider.upload(file_stream, upload_path)
 
         assert created is True
@@ -694,6 +700,11 @@ class TestUploads:
                                    upload_path, upload_response, mock_time):
         self.patch_uuid(monkeypatch)
         provider, inner_provider = provider_and_mock_one
+
+        url, _, params = provider.build_signed_url(
+            'GET', '{}/api/v1/project/foo/creator_quota/'.format(wb_settings.OSF_URL))
+        quota = {'max': 10000, 'used': 0}
+        aiohttpretty.register_json_uri('GET', url, body=quota, params=params)
 
         url = 'https://waterbutler.io/{}/children/'.format(upload_path.parent.identifier)
 
@@ -729,6 +740,11 @@ class TestUploads:
         self.patch_uuid(monkeypatch)
         provider, inner_provider = provider_and_mock_one
 
+        url, _, params = provider.build_signed_url(
+            'GET', '{}/api/v1/project/foo/creator_quota/'.format(wb_settings.OSF_URL))
+        quota = {'max': 10000, 'used': 0}
+        aiohttpretty.register_json_uri('GET', url, body=quota, params=params)
+
         url = 'https://waterbutler.io/{}/children/'.format(upload_path.parent.identifier)
 
         inner_provider.metadata.side_effect = exceptions.MetadataError('Boom!', code=500)
@@ -743,6 +759,12 @@ class TestUploads:
                                 upload_response, mock_time):
         self.patch_uuid(monkeypatch)
         provider, inner_provider = provider_and_mock_one
+
+        url, _, params = provider.build_signed_url(
+            'GET', '{}/api/v1/project/foo/creator_quota/'.format(wb_settings.OSF_URL))
+        quota = {'max': 10000, 'used': 0}
+        aiohttpretty.register_json_uri('GET', url, body=quota, params=params)
+
         path = WaterButlerPath('/{}'.format(upload_response['data']['name']),
                                _ids=('Test', upload_response['data']['id']))
         url = 'https://waterbutler.io/{}/children/'.format(path.parent.identifier)

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -783,6 +783,29 @@ class TestUploads:
             fetch_metadata=False
         )
 
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload_above_quota(self, monkeypatch, provider_and_mock_one, file_stream,
+                              upload_response, upload_path, mock_time):
+        self.patch_uuid(monkeypatch)
+
+        url = 'https://waterbutler.io/{}/children/'.format(upload_path.parent.identifier)
+        aiohttpretty.register_json_uri('POST', url, status=201, body=upload_response)
+
+        provider, inner_provider = provider_and_mock_one
+        inner_provider.metadata = utils.MockCoroutine(return_value=utils.MockFileMetadata())
+
+        url, _, params = provider.build_signed_url(
+            'GET', '{}/api/v1/project/foo/creator_quota/'.format(wb_settings.OSF_URL))
+        quota = {'max': 10000, 'used': 11000}
+        aiohttpretty.register_json_uri('GET', url, body=quota, params=params)
+
+        res, created = await provider.upload(file_stream, upload_path)
+
+        assert created is False
+        assert isinstance(res, dict)
+        assert res['error'] == 'not_enough_quota'
+
 
 class TestCrossRegionMove:
 

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -783,29 +783,6 @@ class TestUploads:
             fetch_metadata=False
         )
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_upload_above_quota(self, monkeypatch, provider_and_mock_one, file_stream,
-                              upload_response, upload_path, mock_time):
-        self.patch_uuid(monkeypatch)
-
-        url = 'https://waterbutler.io/{}/children/'.format(upload_path.parent.identifier)
-        aiohttpretty.register_json_uri('POST', url, status=201, body=upload_response)
-
-        provider, inner_provider = provider_and_mock_one
-        inner_provider.metadata = utils.MockCoroutine(return_value=utils.MockFileMetadata())
-
-        url, _, params = provider.build_signed_url(
-            'GET', '{}/api/v1/project/foo/creator_quota/'.format(wb_settings.OSF_URL))
-        quota = {'max': 10000, 'used': 11000}
-        aiohttpretty.register_json_uri('GET', url, body=quota, params=params)
-
-        res, created = await provider.upload(file_stream, upload_path)
-
-        assert created is False
-        assert isinstance(res, dict)
-        assert res['error'] == 'not_enough_quota'
-
 
 class TestCrossRegionMove:
 

--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -231,24 +231,3 @@ class TestUploadFile:
         handler.write.assert_called_once_with({
             'data': mock_file_metadata.json_api_serialized('3rqws')
         })
-
-    @pytest.mark.asyncio
-    async def test_not_enough_quota(self, handler):
-        handler.resource = '3rqws'
-        metadata = {
-            'error': 'not_enough_quota',
-            'message': 'You do not have enough available quota.',
-            'file': {
-                'name': 'myfile.big',
-                'size': 9999999
-            }
-        }
-        handler.uploader.set_result((metadata, False))
-        handler.set_status = mock.Mock()
-
-        await handler.upload_file()
-
-        assert handler.wsock.close.called
-        assert handler.writer.close.called
-        handler.set_status.assert_called_once_with(406)
-        handler.write.assert_called_once_with(metadata)

--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -24,6 +24,39 @@ class TestValidatePut:
         handler.get_query_argument.assert_called_once_with('name', default=None)
 
     @pytest.mark.asyncio
+    async def test_postvalidate_quota_ok(self, handler):
+        handler.path = WaterButlerPath('/file')
+        handler.kind = 'file'
+        handler.get_query_argument = mock.Mock(return_value=None)
+        handler.provider.NAME = 'osfstorage'
+        handler.provider.get_quota = MockCoroutine(return_value={'used': 0, 'max': 10000})
+        handler.request.headers = {'Content-Length': 5000}
+
+        await handler.postvalidate_put()
+
+        assert handler.target_path == handler.path
+        handler.get_query_argument.assert_called_once_with('name', default=None)
+        handler.provider.get_quota.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_postvalidate_quota_denied(self, handler):
+        handler.path = WaterButlerPath('/file')
+        handler.kind = 'file'
+        handler.get_query_argument = mock.Mock(return_value=None)
+        handler.provider.NAME = 'osfstorage'
+        handler.provider.get_quota = MockCoroutine(return_value={'used': 8000, 'max': 10000})
+        handler.request.headers = {'Content-Length': 5000}
+
+        with pytest.raises(exceptions.NotEnoughQuotaError) as exc:
+            await handler.postvalidate_put()
+
+        assert exc.value.message == 'You do not have enough available quota.'
+
+        assert handler.target_path == handler.path
+        handler.get_query_argument.assert_called_once_with('name', default=None)
+        handler.provider.get_quota.assert_called_once_with()
+
+    @pytest.mark.asyncio
     async def test_postvalidate_put_folder(self, handler):
         handler.path = WaterButlerPath('/Folder1/')
         handler.kind = 'folder'

--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -232,3 +232,23 @@ class TestUploadFile:
             'data': mock_file_metadata.json_api_serialized('3rqws')
         })
 
+    @pytest.mark.asyncio
+    async def test_not_enough_quota(self, handler):
+        handler.resource = '3rqws'
+        metadata = {
+            'error': 'not_enough_quota',
+            'message': 'You do not have enough available quota.',
+            'file': {
+                'name': 'myfile.big',
+                'size': 9999999
+            }
+        }
+        handler.uploader.set_result((metadata, False))
+        handler.set_status = mock.Mock()
+
+        await handler.upload_file()
+
+        assert handler.wsock.close.called
+        assert handler.writer.close.called
+        handler.set_status.assert_called_once_with(406)
+        handler.write.assert_called_once_with(metadata)

--- a/waterbutler/core/exceptions.py
+++ b/waterbutler/core/exceptions.py
@@ -91,6 +91,13 @@ class UnsupportedActionError(WaterButlerError):
                          code=HTTPStatus.BAD_REQUEST, is_user_error=True)
 
 
+class NotEnoughQuotaError(WaterButlerError):
+    """The user does not have enough quota to upload a file
+    """
+    def __init__(self, message, code=HTTPStatus.NOT_ACCEPTABLE):
+        super().__init__(message, code=code)
+
+
 class PluginError(WaterButlerError):
     """WaterButler-related errors raised from a plugin, such as an auth handler or provider, should
     inherit from `PluginError`.

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -342,7 +342,7 @@ class BoxProvider(provider.BaseProvider):
                        path: WaterButlerPath, raw: bool=False, folder=False, revision=None,
                        **kwargs) -> Union[dict, BoxFileMetadata, List[BoxFolderMetadata]]:
         if path.identifier is None:
-            raise exceptions.NotFoundError(str(path))
+            raise exceptions.MetadataError('{} not found'.format(str(path)), code=404)
 
         if path.is_file:
             return await self._get_file_meta(path, revision=revision, raw=raw)

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -269,7 +269,9 @@ class GoogleDriveProvider(provider.BaseProvider):
         if data['md5Checksum'] != stream.writers['md5'].hexdigest:
             raise exceptions.UploadChecksumMismatchError()
 
-        return GoogleDriveFileMetadata(data, path), path.identifier is None
+        created = path.identifier is None
+        path._parts[-1]._id = data.get('id')
+        return GoogleDriveFileMetadata(data, path), created
 
     async def delete(self,  # type: ignore
                      path: GoogleDrivePath,

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -5,6 +5,7 @@ import typing
 import hashlib
 import logging
 
+from waterbutler import settings as wb_settings
 from waterbutler.core import utils
 from waterbutler.core import signing
 from waterbutler.core import streams
@@ -235,6 +236,12 @@ class OSFStorageProvider(provider.BaseProvider):
         Finally, WB constructs its metadata response and sends that back to the original request
         issuer.
         """
+        async with self.signed_request(
+            'GET',
+            '{}/api/v1/project/{}/creator_quota/'.format(wb_settings.OSF_URL, self.nid),
+            expects=(200, )
+        ) as resp:
+            resp_json = await resp.json()
 
         metadata = await self._send_to_storage_provider(stream, path, **kwargs)
         metadata = metadata.serialized()

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -241,7 +241,16 @@ class OSFStorageProvider(provider.BaseProvider):
             '{}/api/v1/project/{}/creator_quota/'.format(wb_settings.OSF_URL, self.nid),
             expects=(200, )
         ) as resp:
-            resp_json = await resp.json()
+            quota = await resp.json()
+            if quota['used'] + stream.size > quota['max']:
+                return {
+                    'error': 'not_enough_quota',
+                    'message': 'You do not have enough available quota.',
+                    'file': {
+                        'name': path.name,
+                        'size': stream.size
+                    }
+                }, False
 
         metadata = await self._send_to_storage_provider(stream, path, **kwargs)
         metadata = metadata.serialized()

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -102,4 +102,9 @@ class CreateMixin:
         if created:
             self.set_status(201)
 
+        if isinstance(self.metadata, dict):
+            self.set_status(406)  # Not acceptable
+            self.write(self.metadata)
+            return
+
         self.write({'data': self.metadata.json_api_serialized(self.resource)})

--- a/waterbutler/settings.py
+++ b/waterbutler/settings.py
@@ -178,4 +178,4 @@ keen_public_config = keen_config.child('PUBLIC')
 KEEN_PUBLIC_PROJECT_ID = keen_public_config.get_nullable('PROJECT_ID', None)
 KEEN_PUBLIC_WRITE_KEY = keen_public_config.get_nullable('WRITE_KEY', None)
 
-OSF_URL = os.environ.get('OSF_URL', 'http://192.168.168.167:5000')
+OSF_URL = config.get('OSF_URL', 'http://192.168.168.167:5000')

--- a/waterbutler/settings.py
+++ b/waterbutler/settings.py
@@ -177,3 +177,5 @@ KEEN_PRIVATE_WRITE_KEY = keen_private_config.get_nullable('WRITE_KEY', None)
 keen_public_config = keen_config.child('PUBLIC')
 KEEN_PUBLIC_PROJECT_ID = keen_public_config.get_nullable('PROJECT_ID', None)
 KEEN_PUBLIC_WRITE_KEY = keen_public_config.get_nullable('WRITE_KEY', None)
+
+OSF_URL = os.environ.get('OSF_URL', 'http://192.168.168.167:5000')


### PR DESCRIPTION
## Ticket
  GRDM#9826

## Purpose
ディスク容量のクォータ機能をPRいたします。
対応するフィーチャーは以下になります。
　【フィーチャー】クォータ制限を超えたファイル登録を抑止する（#9826）

## Changes
## Side effects
## QA Notes
## Deployment Notes
　RCOSDP/RDM-osf.io/commits/feature/inst-sto_quota-restrict_staging
　もあわせてデプロイしてください。
　その際、機能を動作させるためには 、RDM-osf.io 側の .docker-compose.wb.env
　ファイル の OSF_URL 変数を利用できるようにする必要があります。