### PR TITLE
IQB-RIMSアドオン改修(2020年2月)

### DIFF
--- a/tests/providers/iqbrims/test_metadata.py
+++ b/tests/providers/iqbrims/test_metadata.py
@@ -37,7 +37,6 @@ class TestMetadata:
         assert parsed.content_type == item['mimeType']
         assert parsed.extra == {
             'revisionId': item['version'],
-            'webView': item['alternateLink'],
             'hashes': {'md5': item['md5Checksum']},
         }
         assert parsed.path == '/' + os.path.join(*[x.raw for x in path.parts])
@@ -59,7 +58,6 @@ class TestMetadata:
         assert parsed.content_type == item['mimeType']
         assert parsed.extra == {
             'revisionId': item['version'],
-            'webView': item['alternateLink'],
             'hashes': {'md5': item['md5Checksum']},
         }
         assert parsed.path == '/' + os.path.join(*[x.raw for x in path.parts])
@@ -76,7 +74,6 @@ class TestMetadata:
         assert parsed.extra == {
             'revisionId': item['version'],
             'downloadExt': '.docx',
-            'webView': item['alternateLink'],
         }
         assert parsed.is_iqbrims_doc is True
         assert parsed.export_name == item['title'] + '.docx'

--- a/waterbutler/providers/iqbrims/metadata.py
+++ b/waterbutler/providers/iqbrims/metadata.py
@@ -113,7 +113,6 @@ class IQBRIMSFileMetadata(BaseIQBRIMSMetadata, metadata.BaseFileMetadata):
     @property
     def extra(self):
         ret = super().extra
-        ret['webView'] = self.raw.get('alternateLink')
 
         if self.is_iqbrims_doc:
             ret['downloadExt'] = utils.get_download_extension(self.raw)


### PR DESCRIPTION
## Ticket

GRDM-18125

## Purpose

IQB-RIMSアドオンの改修対応(2020年2月)

## Changes

* フォルダ削除、フォルダ作成ロジックの追加(フォルダごと移動可能にするため)
* View on IQB-RIMSボタンを無効化するためのメタデータ調整

## Side effects

None

## QA Notes

None

## Deployment Notes

None