### PR TITLE
RFeature/unicode normalize

### DIFF
--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -1,4 +1,7 @@
+import unicodedata
+
 from waterbutler.core import exceptions
+from waterbutler import settings
 
 
 class CreateMixin:

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -48,6 +48,8 @@ class CreateMixin:
         """
 
         self.childs_name = self.get_query_argument('name', default=None)
+        if self.childs_name is not None and settings.FILENAME_NORMALIZATION_RULE is not None:
+            self.childs_name = unicodedata.normalize(settings.FILENAME_NORMALIZATION_RULE, self.childs_name)
 
         # handle newfile and newfolder naming conflicts
         if self.path.is_dir:

--- a/waterbutler/settings.py
+++ b/waterbutler/settings.py
@@ -179,3 +179,4 @@ KEEN_PUBLIC_PROJECT_ID = keen_public_config.get_nullable('PROJECT_ID', None)
 KEEN_PUBLIC_WRITE_KEY = keen_public_config.get_nullable('WRITE_KEY', None)
 
 OSF_URL = config.get('OSF_URL', 'http://192.168.168.167:5000')
+FILENAME_NORMALIZATION_RULE = config.get('FILENAME_NORMALIZATION_RULE', 'NFC')


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

26855

## Purpose

Windows - Mac 環境でラウンドトリップした際にファイル名のユニコード正規化方式の違いからファイルが更新ではなく新規作成されてしまう問題に対処する。

## Changes

新規ファイルのアップロード時にファイル名にユニコード正規化を施す。

waterbutler.settingsにFILENAME_NORMALIZE_RULEを追加。
[None, 'NFC', 'NFD'] のいずれかを設定する。
既定値はl'NFC'
Noneでパススルー(従来の動作)

## Side effects


## QA Notes


## Deployment Notes

