### PR TITLE
fix: S3CompatB3Provider#_metadata_file raises HTTP code in String. It…

### DIFF
--- a/waterbutler/providers/s3compatb3/provider.py
+++ b/waterbutler/providers/s3compatb3/provider.py
@@ -342,7 +342,7 @@ class S3CompatB3Provider(provider.BaseProvider):
         try:
             resp = self.connection.s3.meta.client.head_object(Bucket=self.bucket.name, Key=path.full_path)
         except ClientError as e:
-            raise exceptions.MetadataError(str(path.full_path), code=e.response['Error']['Code'])
+            raise exceptions.MetadataError(str(path.full_path), code=int(e.response['Error']['Code']))
 
         return S3CompatB3FileMetadataHeaders(self, path.full_path, resp)
 


### PR DESCRIPTION
exceptions.MetadataErrorに与えるHTTPコードが文字列になっていた件の修正