### PR TITLE
Hotfix/32674

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ setuptools==37.0.0
 stevedore==1.2.0
 tornado==6.0.3
 xmltodict==0.9.0
-yarl==1.8.1
+yarl==1.7.2
 
 # Analytics requirements
 python-geoip-geolite2==2015.0303

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ setuptools==37.0.0
 stevedore==1.2.0
 tornado==6.0.3
 xmltodict==0.9.0
+yarl==1.8.1
 
 # Analytics requirements
 python-geoip-geolite2==2015.0303

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -11,6 +11,7 @@ from urllib import parse
 import furl
 import aiohttp
 from aiohttp.client import _RequestContextManager
+from yarl import URL
 
 from waterbutler.core import streams
 from waterbutler.core import exceptions
@@ -286,6 +287,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
         while retry >= 0:
             # Don't overwrite the callable ``url`` so that signed URLs are refreshed for every retry
             non_callable_url = url() if callable(url) else url
+            non_callable_url = URL(non_callable_url, encoded=True)
             try:
                 self.provider_metrics.incr('requests.count')
                 # TODO: use a `dict` to select methods with either `lambda` or `functools.partial`


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

S3系アドオンでURL encodeが必要なファイル名が正しく扱えない問題への対応

-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

32674
ファイル名に括弧を含むフォルダのzipダウンロードに失敗する。

## Purpose

WBのmake_request内で、パラメータとして与えられたURLのパス/パラメータ部に
URL encodeされた文字列が含まれた場合、リクエストの発行前にそれらがデコードされてしまう。
結果としてURL文字列が変化するためストレージサービス側でsignatureの検証にしっぱいしていた。

## Changes

aiohttpにリクエストURLを渡す前にURL文字列を
エンコード済みのフラグの設定されたyarlのURLオブジェクトに差し替える。

## Side effects

リリース判定用の総合テストのテスト項目を通したが、この範囲では問題は確認されていない。

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
