### PR TITLE
Feature/202210 user management/4.4

### DIFF
--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -1049,7 +1049,7 @@ class TestMetadata:
         aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
                                   headers={'Content-Type': 'application/xml'})
 
-        result = await provider._metadata_folder(path, next_marker='')
+        result = await provider._metadata_folder(path, next_token='')
 
         assert isinstance(result, dict)
         assert len(result) == 2

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -165,7 +165,7 @@ def build_folder_params(path):
 
 
 def build_folder_params_with_max_key(path):
-    return {'prefix': path.path, 'delimiter': '/', 'max-keys': '50'}
+    return {'prefix': path.path, 'delimiter': '/', 'max-keys': '1000'}
 
 
 class TestRegionDetection:

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -165,6 +165,7 @@ def list_upload_chunks_body(parts_metadata):
 def build_folder_params(path):
     return {'prefix': path.path, 'delimiter': '/'}
 
+
 def build_folder_params_with_max_key(path):
     return {'prefix': path.path, 'delimiter': '/', 'max-keys': '1000'}
 

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -1,25 +1,15 @@
-import os
-import io
-import xml
-import json
-import time
+import aiohttpretty
 import base64
 import hashlib
-import aiohttpretty
-from http import client
-from urllib import parse
-from unittest import mock
-
+import io
+import json
+import os
 import pytest
+import time
+import xml
 from boto.compat import BytesIO
 from boto.utils import compute_md5
-
-from waterbutler.providers.s3 import S3Provider
-from waterbutler.core.path import WaterButlerPath
-from waterbutler.core import streams, metadata, exceptions
-from waterbutler.providers.s3 import settings as pd_settings
-
-from tests.utils import MockCoroutine
+from http import client
 from tests.providers.s3.fixtures import (auth,
                                          settings,
                                          credentials,
@@ -45,6 +35,14 @@ from tests.providers.s3.fixtures import (auth,
                                          folder_single_item_metadata,
                                          file_metadata_headers_object,
                                          )
+from unittest import mock
+from urllib import parse
+from waterbutler.core import streams, metadata, exceptions
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.providers.s3 import S3Provider
+from waterbutler.providers.s3 import settings as pd_settings
+
+from tests.utils import MockCoroutine
 
 
 @pytest.fixture
@@ -166,25 +164,29 @@ def build_folder_params(path):
     return {'prefix': path.path, 'delimiter': '/'}
 
 
+def build_folder_params_with_max_key(path):
+    return {'prefix': path.path, 'delimiter': '/', 'max-keys': '50'}
+
+
 class TestRegionDetection:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     @pytest.mark.parametrize("region_name,host", [
-        ('',               's3.amazonaws.com'),
-        ('EU',             's3-eu-west-1.amazonaws.com'),
-        ('us-east-2',      's3-us-east-2.amazonaws.com'),
-        ('us-west-1',      's3-us-west-1.amazonaws.com'),
-        ('us-west-2',      's3-us-west-2.amazonaws.com'),
-        ('ca-central-1',   's3-ca-central-1.amazonaws.com'),
-        ('eu-central-1',   's3-eu-central-1.amazonaws.com'),
-        ('eu-west-2',      's3-eu-west-2.amazonaws.com'),
+        ('', 's3.amazonaws.com'),
+        ('EU', 's3-eu-west-1.amazonaws.com'),
+        ('us-east-2', 's3-us-east-2.amazonaws.com'),
+        ('us-west-1', 's3-us-west-1.amazonaws.com'),
+        ('us-west-2', 's3-us-west-2.amazonaws.com'),
+        ('ca-central-1', 's3-ca-central-1.amazonaws.com'),
+        ('eu-central-1', 's3-eu-central-1.amazonaws.com'),
+        ('eu-west-2', 's3-eu-west-2.amazonaws.com'),
         ('ap-northeast-1', 's3-ap-northeast-1.amazonaws.com'),
         ('ap-northeast-2', 's3-ap-northeast-2.amazonaws.com'),
-        ('ap-south-1',     's3-ap-south-1.amazonaws.com'),
+        ('ap-south-1', 's3-ap-south-1.amazonaws.com'),
         ('ap-southeast-1', 's3-ap-southeast-1.amazonaws.com'),
         ('ap-southeast-2', 's3-ap-southeast-2.amazonaws.com'),
-        ('sa-east-1',      's3-sa-east-1.amazonaws.com'),
+        ('sa-east-1', 's3-sa-east-1.amazonaws.com'),
     ])
     async def test_region_host(self, auth, credentials, settings, region_name, host, mock_time):
         provider = S3Provider(auth, credentials, settings)
@@ -295,7 +297,7 @@ class TestCRUD:
     async def test_download(self, provider, mock_time):
         path = WaterButlerPath('/muhtriangle')
         response_headers = {'response-content-disposition':
-                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+                                'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         url = provider.bucket.new_key(path.path).generate_url(100,
                                                               response_headers=response_headers)
         aiohttpretty.register_uri('GET', url, body=b'delicious', auto_length=True)
@@ -310,7 +312,7 @@ class TestCRUD:
     async def test_download_range(self, provider, mock_time):
         path = WaterButlerPath('/muhtriangle')
         response_headers = {'response-content-disposition':
-                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+                                'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         url = provider.bucket.new_key(path.path).generate_url(100,
                                                               response_headers=response_headers)
         aiohttpretty.register_uri('GET', url, body=b'de', auto_length=True, status=206)
@@ -326,7 +328,7 @@ class TestCRUD:
     async def test_download_version(self, provider, mock_time):
         path = WaterButlerPath('/muhtriangle')
         response_headers = {'response-content-disposition':
-                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+                                'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         url = provider.bucket.new_key(path.path).generate_url(
             100,
             query_parameters={'versionId': 'someversion'},
@@ -343,8 +345,8 @@ class TestCRUD:
     @pytest.mark.aiohttpretty
     @pytest.mark.parametrize("display_name_arg,expected_name", [
         ('meow.txt', 'meow.txt'),
-        ('',         'muhtriangle'),
-        (None,       'muhtriangle'),
+        ('', 'muhtriangle'),
+        (None, 'muhtriangle'),
     ])
     async def test_download_with_display_name(self, provider, mock_time, display_name_arg,
                                               expected_name):
@@ -368,7 +370,7 @@ class TestCRUD:
     async def test_download_not_found(self, provider, mock_time):
         path = WaterButlerPath('/muhtriangle')
         response_headers = {'response-content-disposition':
-                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+                                'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         url = provider.bucket.new_key(path.path).generate_url(100,
                                                               response_headers=response_headers)
         aiohttpretty.register_uri('GET', url, status=404)
@@ -391,7 +393,6 @@ class TestCRUD:
                                  file_stream,
                                  file_header_metadata,
                                  mock_time):
-
         path = WaterButlerPath('/foobah')
         content_md5 = hashlib.md5(file_content).hexdigest()
         url = provider.bucket.new_key(path.path).generate_url(100, 'PUT')
@@ -415,7 +416,6 @@ class TestCRUD:
                                     file_stream,
                                     file_header_metadata,
                                     mock_time):
-
         # Set trigger for encrypt_key=True in s3.provider.upload
         provider.encrypt_uploads = True
         path = WaterButlerPath('/foobah')
@@ -430,7 +430,7 @@ class TestCRUD:
                 {'headers': file_header_metadata},
             ],
         )
-        headers={'ETag': '"{}"'.format(content_md5)}
+        headers = {'ETag': '"{}"'.format(content_md5)}
         aiohttpretty.register_uri('PUT', url, status=200, headers=headers)
 
         metadata, created = await provider.upload(file_stream, path)
@@ -556,7 +556,6 @@ class TestCRUD:
     @pytest.mark.aiohttpretty
     async def test_chunked_upload_upload_parts_remainder(self, provider,
                                                          upload_parts_headers_list):
-
         file_stream = streams.StringStream('abcdefghijklmnopqrst')
         assert file_stream.size == 20
         provider.CHUNK_SIZE = 9
@@ -634,7 +633,7 @@ class TestCRUD:
         headers_list = [{k.upper(): v for k, v in headers.items()} for headers in headers_list]
         for i, part in enumerate(headers_list):
             payload += '<Part>'
-            payload += '<PartNumber>{}</PartNumber>'.format(i+1)  # part number must be >= 1
+            payload += '<PartNumber>{}</PartNumber>'.format(i + 1)  # part number must be >= 1
             payload += '<ETag>{}</ETag>'.format(xml.sax.saxutils.escape(part['ETAG']))
             payload += '</Part>'
         payload += '</CompleteMultipartUpload>'
@@ -913,7 +912,6 @@ class TestCRUD:
         )
         aiohttpretty.register_uri('POST', delete_url, status=204)
 
-
         await provider.delete(path)
         assert aiohttpretty.has_call(method='GET', uri=query_url, params=params)
         aiohttpretty.register_uri('POST', delete_url, status=204)
@@ -1000,7 +998,7 @@ class TestCRUD:
     async def test_accepts_url(self, provider, mock_time):
         path = WaterButlerPath('/my-image')
         response_headers = {'response-content-disposition':
-                            'attachment; filename="my-image"; filename*=UTF-8\'\'my-image'}
+                                'attachment; filename="my-image"; filename*=UTF-8\'\'my-image'}
         url = provider.bucket.new_key(path.path).generate_url(100,
                                                               'GET',
                                                               response_headers=response_headers)
@@ -1011,54 +1009,77 @@ class TestCRUD:
 
 
 class TestMetadata:
-
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_metadata_folder(self, provider, folder_metadata, mock_time):
         path = WaterButlerPath('/darp/')
         url = provider.bucket.generate_url(100)
-        params = build_folder_params(path)
+        params = build_folder_params_with_max_key(path)
+
         aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
                                   headers={'Content-Type': 'application/xml'})
 
         result = await provider.metadata(path)
 
-        assert isinstance(result, list)
-        assert len(result) == 3
-        assert result[0].name == '   photos'
-        assert result[1].name == 'my-image.jpg'
-        assert result[2].extra['md5'] == '1b2cf535f27731c974343645a3985328'
-        assert result[2].extra['hashes']['md5'] == '1b2cf535f27731c974343645a3985328'
+        assert isinstance(result, dict)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_have_next_maker(self, provider, folder_metadata, mock_time):
+        path = WaterButlerPath('/darp/')
+        url = provider.bucket.generate_url(100)
+        params = build_folder_params_with_max_key(path)
+
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        result = await provider.metadata(path, revision=None, next_marker='')
+
+        assert isinstance(result, dict)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_folder_have_next_maker(self, provider, folder_metadata, mock_time):
+        path = WaterButlerPath('/darp/')
+        url = provider.bucket.generate_url(100)
+        params = build_folder_params_with_max_key(path)
+
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        result = await provider._metadata_folder(path, next_marker='')
+
+        assert isinstance(result, dict)
+        assert len(result) == 2
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_metadata_folder_self_listing(self, provider, folder_and_contents, mock_time):
         path = WaterButlerPath('/thisfolder/')
         url = provider.bucket.generate_url(100)
-        params = build_folder_params(path)
+        params = build_folder_params_with_max_key(path)
         aiohttpretty.register_uri('GET', url, params=params, body=folder_and_contents)
 
         result = await provider.metadata(path)
 
-        assert isinstance(result, list)
+        assert isinstance(result, dict)
         assert len(result) == 2
-        for fobj in result:
-            assert fobj.name != path.path
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_folder_metadata_folder_item(self, provider, folder_item_metadata, mock_time):
         path = WaterButlerPath('/')
         url = provider.bucket.generate_url(100)
-        params = build_folder_params(path)
+        params = build_folder_params_with_max_key(path)
         aiohttpretty.register_uri('GET', url, params=params, body=folder_item_metadata,
                                   headers={'Content-Type': 'application/xml'})
 
         result = await provider.metadata(path)
 
-        assert isinstance(result, list)
-        assert len(result) == 1
-        assert result[0].kind == 'folder'
+        assert isinstance(result, dict)
+        assert len(result) == 2
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -1067,19 +1088,17 @@ class TestMetadata:
         metadata_url = provider.bucket.new_key(path.path).generate_url(100, 'HEAD')
 
         url = provider.bucket.generate_url(100)
-        params = build_folder_params(path)
+        params = build_folder_params_with_max_key(path)
         aiohttpretty.register_uri('GET', url, params=params, body=folder_empty_metadata,
                                   headers={'Content-Type': 'application/xml'})
-
 
         aiohttpretty.register_uri('HEAD', metadata_url, header=folder_empty_metadata,
                                   headers={'Content-Type': 'application/xml'})
 
         result = await provider.metadata(path)
 
-        assert isinstance(result, list)
-        assert len(result) == 0
-
+        assert isinstance(result, dict)
+        assert len(result) == 2
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -1129,7 +1148,6 @@ class TestMetadata:
                           file_stream,
                           file_header_metadata,
                           mock_time):
-
         path = WaterButlerPath('/foobah')
         content_md5 = hashlib.md5(file_content).hexdigest()
         url = provider.bucket.new_key(path.path).generate_url(100, 'PUT')
@@ -1186,7 +1204,7 @@ class TestCreateFolder:
     async def test_raise_409(self, provider, folder_metadata, mock_time):
         path = WaterButlerPath('/alreadyexists/')
         url = provider.bucket.generate_url(100, 'GET')
-        params = build_folder_params(path)
+        params = build_folder_params_with_max_key(path)
         aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
                                   headers={'Content-Type': 'application/xml'})
 
@@ -1210,10 +1228,21 @@ class TestCreateFolder:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_create_folder_with_folder_precheck_is_false(self, provider, mock_time):
+        path = WaterButlerPath('/alreadyexists')
+
+        with pytest.raises(exceptions.CreateFolderError) as e:
+            await provider.create_folder(path, folder_precheck=False)
+
+        assert e.value.code == 400
+        assert e.value.message == 'Path must be a directory'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_errors_out(self, provider, mock_time):
         path = WaterButlerPath('/alreadyexists/')
         url = provider.bucket.generate_url(100, 'GET')
-        params = build_folder_params(path)
+        params = build_folder_params_with_max_key(path)
         create_url = provider.bucket.new_key(path.path).generate_url(100, 'PUT')
 
         aiohttpretty.register_uri('GET', url, params=params, status=404)
@@ -1229,7 +1258,7 @@ class TestCreateFolder:
     async def test_errors_out_metadata(self, provider, mock_time):
         path = WaterButlerPath('/alreadyexists/')
         url = provider.bucket.generate_url(100, 'GET')
-        params = build_folder_params(path)
+        params = build_folder_params_with_max_key(path)
 
         aiohttpretty.register_uri('GET', url, params=params, status=403)
 
@@ -1243,7 +1272,7 @@ class TestCreateFolder:
     async def test_creates(self, provider, mock_time):
         path = WaterButlerPath('/doesntalreadyexists/')
         url = provider.bucket.generate_url(100, 'GET')
-        params = build_folder_params(path)
+        params = build_folder_params_with_max_key(path)
         create_url = provider.bucket.new_key(path.path).generate_url(100, 'PUT')
 
         aiohttpretty.register_uri('GET', url, params=params, status=404)
@@ -1274,7 +1303,6 @@ class TestOperations:
         aiohttpretty.register_uri('PUT', url, status=200)
 
         metadata, exists = await provider.intra_copy(provider, source_path, dest_path)
-
 
         provider._check_region.assert_called()
 

--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -550,8 +550,10 @@ def build_folder_params(path):
     prefix = path.full_path.lstrip('/')
     return {'prefix': prefix, 'delimiter': '/'}
 
+
 def build_folder_params_with_max_key(path):
     return {'prefix': path.path, 'delimiter': '/', 'max-keys': '1000'}
+
 
 def list_upload_chunks_body(parts_metadata):
     payload = '''<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -1441,7 +1441,7 @@ class TestMetadata:
         aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
                                   headers={'Content-Type': 'application/xml'})
 
-        result = await provider.metadata(path, revision=None, next_marker='')
+        result = await provider.metadata(path, revision=None, next_token='')
 
         assert isinstance(result, dict)
         assert len(result) == 2

--- a/tests/server/api/v1/fixtures.py
+++ b/tests/server/api/v1/fixtures.py
@@ -65,10 +65,7 @@ def mock_folder_children():
 
 @pytest.fixture()
 def mock_folder_children_provider_s3():
-    data = dict()
-    data['data'] = [MockFolderMetadata()]
-    data['next_token'] = 'aaaa'
-    return data
+    return [MockFolderMetadata(), 'aaaa']
 
 
 @pytest.fixture

--- a/tests/server/api/v1/fixtures.py
+++ b/tests/server/api/v1/fixtures.py
@@ -1,17 +1,16 @@
-import os
-import sys
 import json
-from unittest import mock
-
+import os
 import pytest
-from tornado.web import HTTPError
-from tornado.httputil import HTTPServerRequest
+import sys
 from tornado.http1connection import HTTP1ConnectionParameters
+from tornado.httputil import HTTPServerRequest
+from tornado.web import HTTPError
+from unittest import mock
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.server.api.v1.provider import ProviderHandler
+from waterbutler.tasks.exceptions import WaitTimeOutError
 
 import waterbutler
-from waterbutler.core.path import WaterButlerPath
-from waterbutler.tasks.exceptions import WaitTimeOutError
-from waterbutler.server.api.v1.provider import ProviderHandler
 from tests.utils import (MockProvider, MockFileMetadata, MockFolderMetadata,
                          MockFileRevisionMetadata, MockCoroutine, MockRequestBody, MockStream)
 
@@ -61,6 +60,14 @@ def mock_revision_metadata():
 @pytest.fixture()
 def mock_folder_children():
     return [MockFolderMetadata(), MockFileMetadata(), MockFileMetadata()]
+
+
+@pytest.fixture()
+def mock_folder_children_provider_s3():
+    data = dict()
+    data['data'] = [MockFolderMetadata()]
+    data['next_token'] = 'aaaa'
+    return data
 
 
 @pytest.fixture
@@ -180,42 +187,42 @@ def move_copy_args():
 @pytest.fixture
 def celery_src_copy_params():
     return {
-            'nid': 'test_source_resource',
-            'path': WaterButlerPath('/test_path', prepend=None),
-            'provider': {
-                'credentials': {},
-                'name': 'MockProvider',
-                'settings': {},
-                'auth': {}
-            }
+        'nid': 'test_source_resource',
+        'path': WaterButlerPath('/test_path', prepend=None),
+        'provider': {
+            'credentials': {},
+            'name': 'MockProvider',
+            'settings': {},
+            'auth': {}
+        }
     }
 
 
 @pytest.fixture
 def celery_dest_copy_params():
     return {
-            'nid': 'test_source_resource',
-            'path': WaterButlerPath('/test_path/', prepend=None),
-            'provider': {
-                'credentials': {},
-                'name': 'MockProvider',
-                'settings': {},
-                'auth': {}
-            }
+        'nid': 'test_source_resource',
+        'path': WaterButlerPath('/test_path/', prepend=None),
+        'provider': {
+            'credentials': {},
+            'name': 'MockProvider',
+            'settings': {},
+            'auth': {}
+        }
     }
 
 
 @pytest.fixture
 def celery_dest_copy_params_root():
     return {
-            'nid': 'test_source_resource',
-            'path': WaterButlerPath('/', prepend=None),
-            'provider': {
-                'credentials': {},
-                'name': 'MockProvider',
-                'settings': {},
-                'auth': {}
-            }
+        'nid': 'test_source_resource',
+        'path': WaterButlerPath('/', prepend=None),
+        'provider': {
+            'credentials': {},
+            'name': 'MockProvider',
+            'settings': {},
+            'auth': {}
+        }
     }
 
 
@@ -235,3 +242,27 @@ def serialized_metadata():
 def serialized_request():
     with open(os.path.join(os.path.dirname(__file__), 'fixtures/fixtures.json'), 'r') as fp:
         return json.load(fp)['serialized_request']
+
+
+@pytest.fixture
+def auth():
+    return {
+        'name': 'cat',
+        'email': 'cat@cat.com',
+    }
+
+
+@pytest.fixture
+def credentials():
+    return {
+        'access_key': 'Dont dead',
+        'secret_key': 'open inside',
+    }
+
+
+@pytest.fixture
+def settings():
+    return {
+        'bucket': 'that kerning',
+        'encrypt_uploads': False
+    }

--- a/tests/server/api/v1/fixtures.py
+++ b/tests/server/api/v1/fixtures.py
@@ -1,16 +1,17 @@
-import json
 import os
-import pytest
 import sys
-from tornado.http1connection import HTTP1ConnectionParameters
-from tornado.httputil import HTTPServerRequest
-from tornado.web import HTTPError
+import json
 from unittest import mock
-from waterbutler.core.path import WaterButlerPath
-from waterbutler.server.api.v1.provider import ProviderHandler
-from waterbutler.tasks.exceptions import WaitTimeOutError
+
+import pytest
+from tornado.web import HTTPError
+from tornado.httputil import HTTPServerRequest
+from tornado.http1connection import HTTP1ConnectionParameters
 
 import waterbutler
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.tasks.exceptions import WaitTimeOutError
+from waterbutler.server.api.v1.provider import ProviderHandler
 from tests.utils import (MockProvider, MockFileMetadata, MockFolderMetadata,
                          MockFileRevisionMetadata, MockCoroutine, MockRequestBody, MockStream)
 
@@ -187,42 +188,42 @@ def move_copy_args():
 @pytest.fixture
 def celery_src_copy_params():
     return {
-        'nid': 'test_source_resource',
-        'path': WaterButlerPath('/test_path', prepend=None),
-        'provider': {
-            'credentials': {},
-            'name': 'MockProvider',
-            'settings': {},
-            'auth': {}
-        }
+            'nid': 'test_source_resource',
+            'path': WaterButlerPath('/test_path', prepend=None),
+            'provider': {
+                'credentials': {},
+                'name': 'MockProvider',
+                'settings': {},
+                'auth': {}
+            }
     }
 
 
 @pytest.fixture
 def celery_dest_copy_params():
     return {
-        'nid': 'test_source_resource',
-        'path': WaterButlerPath('/test_path/', prepend=None),
-        'provider': {
-            'credentials': {},
-            'name': 'MockProvider',
-            'settings': {},
-            'auth': {}
-        }
+            'nid': 'test_source_resource',
+            'path': WaterButlerPath('/test_path/', prepend=None),
+            'provider': {
+                'credentials': {},
+                'name': 'MockProvider',
+                'settings': {},
+                'auth': {}
+            }
     }
 
 
 @pytest.fixture
 def celery_dest_copy_params_root():
     return {
-        'nid': 'test_source_resource',
-        'path': WaterButlerPath('/', prepend=None),
-        'provider': {
-            'credentials': {},
-            'name': 'MockProvider',
-            'settings': {},
-            'auth': {}
-        }
+            'nid': 'test_source_resource',
+            'path': WaterButlerPath('/', prepend=None),
+            'provider': {
+                'credentials': {},
+                'name': 'MockProvider',
+                'settings': {},
+                'auth': {}
+            }
     }
 
 

--- a/tests/server/api/v1/test_metadata_mixin.py
+++ b/tests/server/api/v1/test_metadata_mixin.py
@@ -1,15 +1,15 @@
 import json
+
 import pytest
-from tests.server.api.v1.fixtures import (http_request, handler_auth, mock_stream,
-                                          mock_partial_stream, mock_file_metadata,
-                                          mock_folder_children, mock_revision_metadata,
-                                          mock_folder_children_provider_s3, auth, settings, credentials, )
-from tests.server.api.v1.utils import mock_handler
-from waterbutler.core.path import WaterButlerPath
-from waterbutler.providers.s3 import S3Provider
 
 from tests.utils import MockCoroutine
+from waterbutler.core.path import WaterButlerPath
 
+from tests.server.api.v1.utils import mock_handler
+from tests.server.api.v1.fixtures import (http_request, handler_auth, mock_stream,
+                                          mock_partial_stream, mock_file_metadata,
+                                          mock_folder_children, mock_revision_metadata)
+from waterbutler.providers.s3 import S3Provider
 
 @pytest.fixture
 def provider(auth, credentials, settings):
@@ -22,6 +22,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_header_file_metadata(self, http_request, mock_file_metadata):
+
         handler = mock_handler(http_request)
         handler.provider.metadata = MockCoroutine(return_value=mock_file_metadata)
 
@@ -44,6 +45,7 @@ class TestMetadataMixin:
         serialized_data = [x.json_api_serialized(handler.resource) for x in mock_folder_children]
 
         await handler.get_folder()
+
         handler.write.assert_called_once_with({'data': serialized_data})
 
     @pytest.mark.asyncio
@@ -65,7 +67,7 @@ class TestMetadataMixin:
         assert isinstance(serialized_data, dict)
 
     @pytest.mark.asyncio
-    async def test_get_folder_download_as_zip(self, http_request, ):
+    async def test_get_folder_download_as_zip(self, http_request,):
         # Including 'zip' in the query params should trigger the download_as_zip method
 
         handler = mock_handler(http_request)
@@ -78,6 +80,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_get_file_metadata(self, http_request):
+
         handler = mock_handler(http_request)
         handler.file_metadata = MockCoroutine()
         handler.request.query_arguments['meta'] = ''
@@ -102,6 +105,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_get_file_download_file(self, http_request):
+
         handler = mock_handler(http_request)
         handler.download_file = MockCoroutine()
         await handler.get_file()
@@ -110,6 +114,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_download_file_headers(self, http_request, mock_stream):
+
         handler = mock_handler(http_request)
         mock_stream.name = 'peanut-butter.docx'
         handler.provider.download = MockCoroutine(return_value=mock_stream)
@@ -126,6 +131,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_download_file_headers_no_stream_name(self, http_request, mock_stream):
+
         handler = mock_handler(http_request)
         handler.provider.download = MockCoroutine(return_value=mock_stream)
         handler.path = WaterButlerPath('/test_file')
@@ -142,11 +148,12 @@ class TestMetadataMixin:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("given_arg,expected_name,filtered_name", [
         (['résumé.doc'], 'r%C3%A9sum%C3%A9.doc', 'resume.doc'),
-        ([''], 'test_file', 'test_file'),
-        ([], 'test_file', 'test_file'),
+        ([''],           'test_file',            'test_file'),
+        ([],             'test_file',            'test_file'),
     ])
     async def test_download_file_with_display_name(self, http_request, mock_stream, given_arg,
                                                    expected_name, filtered_name):
+
         handler = mock_handler(http_request)
         handler.provider.download = MockCoroutine(return_value=mock_stream)
         handler.path = WaterButlerPath('/test_file')
@@ -163,6 +170,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_download_file_range_request_header(self, http_request, mock_partial_stream):
+
         handler = mock_handler(http_request)
         handler.request.headers['Range'] = 'bytes=10-100'
         handler.provider.download = MockCoroutine(return_value=mock_partial_stream)
@@ -176,6 +184,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_download_file_stream_redirect(self, http_request):
+
         handler = mock_handler(http_request)
         handler.provider.download = MockCoroutine(return_value='stream')
         await handler.download_file()
@@ -202,6 +211,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_file_metadata(self, http_request, mock_file_metadata):
+
         handler = mock_handler(http_request)
         handler.provider.metadata = MockCoroutine(return_value=mock_file_metadata)
 
@@ -213,6 +223,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_file_metadata_version(self, http_request, mock_file_metadata):
+
         handler = mock_handler(http_request)
         handler.provider.metadata = MockCoroutine(return_value=mock_file_metadata)
         handler.requested_version = 'version id'
@@ -226,6 +237,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_get_file_revisions_raw(self, http_request, mock_revision_metadata):
+
         handler = mock_handler(http_request)
         handler.provider.revisions = MockCoroutine(return_value=mock_revision_metadata)
 
@@ -237,6 +249,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_download_folder_as_zip(self, http_request, mock_stream):
+
         handler = mock_handler(http_request)
 
         handler.provider.zip = MockCoroutine(return_value=mock_stream)
@@ -252,6 +265,7 @@ class TestMetadataMixin:
 
     @pytest.mark.asyncio
     async def test_download_folder_as_zip_root(self, http_request, mock_stream):
+
         handler = mock_handler(http_request)
 
         handler.provider.zip = MockCoroutine(return_value=mock_stream)

--- a/tests/server/api/v1/test_metadata_mixin.py
+++ b/tests/server/api/v1/test_metadata_mixin.py
@@ -8,7 +8,8 @@ from waterbutler.core.path import WaterButlerPath
 from tests.server.api.v1.utils import mock_handler
 from tests.server.api.v1.fixtures import (http_request, handler_auth, mock_stream,
                                           mock_partial_stream, mock_file_metadata,
-                                          mock_folder_children, mock_revision_metadata)
+                                          mock_folder_children, mock_revision_metadata,
+                                          mock_folder_children_provider_s3, auth, settings, credentials)
 from waterbutler.providers.s3 import S3Provider
 
 @pytest.fixture

--- a/tests/server/api/v1/test_metadata_mixin.py
+++ b/tests/server/api/v1/test_metadata_mixin.py
@@ -12,6 +12,7 @@ from tests.server.api.v1.fixtures import (http_request, handler_auth, mock_strea
                                           mock_folder_children_provider_s3, auth, settings, credentials)
 from waterbutler.providers.s3 import S3Provider
 
+
 @pytest.fixture
 def provider(auth, credentials, settings):
     provider = S3Provider(auth, credentials, settings)

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -772,6 +772,9 @@ class BaseProvider(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
+    def handle_data(self, data):
+        return data, None
+
     @abc.abstractmethod
     async def validate_v1_path(self, path: str, **kwargs) -> wb_path.WaterButlerPath:
         """API v1 requires that requests against folder endpoints always end with a slash, and

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -638,7 +638,7 @@ class S3Provider(provider.BaseProvider):
 
         if path.is_dir:
             if 'next_token' in kwargs:
-                return (await self._metadata_folder(path, kwargs['next_token']))
+                return await self._metadata_folder(path, kwargs['next_token'])
             return (await self._metadata_folder(path))
 
         return (await self._metadata_file(path, revision=revision))
@@ -702,6 +702,7 @@ class S3Provider(provider.BaseProvider):
         contents = await resp.read()
 
         parsed = xmltodict.parse(contents, strip_whitespace=False)['ListBucketResult']
+
         next_token_string = parsed.get('NextMarker', '')
         contents = parsed.get('Contents', [])
         prefixes = parsed.get('CommonPrefixes', [])
@@ -720,6 +721,7 @@ class S3Provider(provider.BaseProvider):
 
         if isinstance(contents, dict):
             contents = [contents]
+
         if isinstance(prefixes, dict):
             prefixes = [prefixes]
 

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -643,6 +643,11 @@ class S3Provider(provider.BaseProvider):
 
         return (await self._metadata_file(path, revision=revision))
 
+    def handle_data(self, data):
+        token = data.pop()
+
+        return data, token or ''
+
     async def create_folder(self, path, folder_precheck=True, **kwargs):
         """
         :param str path: The path to create a folder at
@@ -739,10 +744,8 @@ class S3Provider(provider.BaseProvider):
             else:
                 items.append(S3FileMetadata(content))
 
-        result = dict()
-        result['data'] = items
-        result['next_token'] = next_token_string
-        return result
+        items.append(next_token_string)
+        return items
 
     async def _check_region(self):
         """Lookup the region via bucket name, then update the host to match.

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -681,7 +681,7 @@ class S3CompatProvider(provider.BaseProvider):
         """
         if path.is_dir:
             if 'next_token' in kwargs:
-                return (await self._metadata_folder(path, kwargs['next_token']))
+                return await self._metadata_folder(path, kwargs['next_token'])
             return (await self._metadata_folder(path))
 
         return (await self._metadata_file(path, revision=revision))
@@ -738,6 +738,7 @@ class S3CompatProvider(provider.BaseProvider):
         contents = await resp.read()
 
         parsed = xmltodict.parse(contents, strip_whitespace=False)['ListBucketResult']
+
         next_token_string = parsed.get('NextMarker', '')
         contents = parsed.get('Contents', [])
         prefixes = parsed.get('CommonPrefixes', [])

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -724,7 +724,7 @@ class S3CompatProvider(provider.BaseProvider):
 
     async def _metadata_folder(self, path, next_token=None):
         prefix = path.full_path.lstrip('/')  # '/' -> '', '/A/B' -> 'A/B'
-        params = {'prefix': prefix, 'delimiter': '/'}
+        params = {'prefix': prefix, 'delimiter': '/', 'max-keys': '1000'}
         if next_token is not None:
             params['marker'] = next_token
         resp = await self.make_request(

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -686,6 +686,11 @@ class S3CompatProvider(provider.BaseProvider):
 
         return (await self._metadata_file(path, revision=revision))
 
+    def handle_data(self, data):
+        token = data.pop()
+
+        return data, token or ''
+
     async def create_folder(self, path, folder_precheck=True, **kwargs):
         """
         :param str path: The path to create a folder at
@@ -775,7 +780,5 @@ class S3CompatProvider(provider.BaseProvider):
             else:
                 items.append(S3CompatFileMetadata(self, content))
 
-        result = dict()
-        result['data'] = items
-        result['next_token'] = next_token_string
-        return result
+        items.append(next_token_string)
+        return items


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

## Purpose

フォルダあたりのファイル数上限の改善

To get the next object list from 'Amazon S3'/'S3 Compatible Storage' storages:
  - Add the 'next_token' parameter to carry value and pass as the 'marker' parameter in APIs of s3/s3compat providers

## Changes

waterbutler/core/provider.py
waterbutler/providers/s3/provider.py
waterbutler/providers/s3compat/provider.py
waterbutler/server/api/v1/provider/metadata.py

tests/providers/s3/test_provider.py
tests/providers/s3compat/test_provider.py
tests/server/api/v1/fixtures.py
tests/server/api/v1/test_metadata_mixin.py

## Side effects


## QA Notes


## Deployment Notes

