### PR TITLE
Hotfix/s3compat disabled intra copy

### DIFF
--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -1395,8 +1395,8 @@ class TestOperations:
         file_path = WaterButlerPath('/my-image.jpg')
         folder_path = WaterButlerPath('/folder/', folder=True)
 
-        assert provider.can_intra_move(provider)
-        assert provider.can_intra_move(provider, file_path)
+        assert not provider.can_intra_move(provider)
+        assert not provider.can_intra_move(provider, file_path)
         assert not provider.can_intra_move(provider, folder_path)
 
     def test_can_intra_copy(self, provider):
@@ -1404,8 +1404,8 @@ class TestOperations:
         file_path = WaterButlerPath('/my-image.jpg')
         folder_path = WaterButlerPath('/folder/', folder=True)
 
-        assert provider.can_intra_copy(provider)
-        assert provider.can_intra_copy(provider, file_path)
+        assert not provider.can_intra_copy(provider)
+        assert not provider.can_intra_copy(provider, file_path)
         assert not provider.can_intra_copy(provider, folder_path)
 
     def test_can_duplicate_names(self, provider):

--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -1755,8 +1755,8 @@ class TestOperations:
         assert aiohttpretty.has_call(method='GET', uri=url, params=params)
 
     async def test_equality(self, provider, mock_time):
-        assert provider.can_intra_copy(provider)
-        assert provider.can_intra_move(provider)
+        assert not provider.can_intra_copy(provider)
+        assert not provider.can_intra_move(provider)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -1788,8 +1788,8 @@ class TestOperations:
         file_path = WaterButlerPath('/my-image.jpg', prepend=provider.prefix)
         folder_path = WaterButlerPath('/folder/', folder=True, prepend=provider.prefix)
 
-        assert provider.can_intra_move(provider)
-        assert provider.can_intra_move(provider, file_path)
+        assert not provider.can_intra_move(provider)
+        assert not provider.can_intra_move(provider, file_path)
         assert not provider.can_intra_move(provider, folder_path)
 
     def test_can_intra_copy(self, provider):
@@ -1797,8 +1797,8 @@ class TestOperations:
         file_path = WaterButlerPath('/my-image.jpg', prepend=provider.prefix)
         folder_path = WaterButlerPath('/folder/', folder=True, prepend=provider.prefix)
 
-        assert provider.can_intra_copy(provider)
-        assert provider.can_intra_copy(provider, file_path)
+        assert not provider.can_intra_copy(provider)
+        assert not provider.can_intra_copy(provider, file_path)
         assert not provider.can_intra_copy(provider, folder_path)
 
     def test_can_duplicate_names(self, provider):

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -104,10 +104,10 @@ class S3Provider(provider.BaseProvider):
         return True
 
     def can_intra_copy(self, dest_provider, path=None):
-        return type(self) == type(dest_provider) and not getattr(path, 'is_dir', False)
+        return False
 
     def can_intra_move(self, dest_provider, path=None):
-        return type(self) == type(dest_provider) and not getattr(path, 'is_dir', False)
+        return False
 
     async def intra_copy(self, dest_provider, source_path, dest_path):
         """Copy key from one S3 bucket to another. The credentials specified in

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -146,10 +146,10 @@ class S3CompatProvider(provider.BaseProvider):
         return True
 
     def can_intra_copy(self, dest_provider, path=None):
-        return type(self) == type(dest_provider) and not getattr(path, 'is_dir', False)
+        return False
 
     def can_intra_move(self, dest_provider, path=None):
-        return type(self) == type(dest_provider) and not getattr(path, 'is_dir', False)
+        return False
 
     async def intra_copy(self, dest_provider, source_path, dest_path):
         """Copy key from one S3 Compatible Storage bucket to another. The credentials specified in


### PR DESCRIPTION
## Purpose

S3系のプロバイダにおいて5GB以上のファイルを扱う際に同一プロバイダ内でのファイルコピー/移動に失敗する問題に対処する。

## Changes

S3の CopyObject API が5GB越えのファイルを扱えないことが原因であるので、このAPIの利用を禁止する。
https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html

## Side effects

5GB以下のファイルで、従来CopyObject APIの利益を得られていたファイルのコピー/移動について
ネットワーク転送分の性能的ペナルティが発生する。

## Deployment Notes

今回は暫定対処として問題となるAPIの利用を一律停止しているが、APIが利用可能なケースではAPIを利用するような改修を予定している。
