### PR TITLE
Feature/202210 institutional storage control/fixedbug/38466

### DIFF
--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -797,16 +797,22 @@ class TestIntraMoveCopy:
             'from_path': src_path.full_path.rstrip('/'),
             'to_path': dest_path.full_path.rstrip('/')
         }
-        aiohttpretty.register_json_uri('POST', url, **{
-            "responses": [
-                {
+        conflict_response = {
                     'headers': {'Content-Type': 'application/json'},
                     'data': data,
                     'body': json.dumps(
                                 error_fixtures['rename_conflict_folder_metadata']
                             ).encode('utf-8'),
                     'status': HTTPStatus.CONFLICT
-                },
+                }
+        aiohttpretty.register_json_uri('POST', url, **{
+            "responses": [
+                conflict_response,
+                conflict_response,
+                conflict_response,
+                conflict_response,
+                conflict_response,
+                conflict_response,
                 {
                     'headers': {'Content-Type': 'application/json'},
                     'data': data,
@@ -950,14 +956,20 @@ class TestIntraMoveCopy:
            'from_path': src_path.full_path.rstrip('/'),
            'to_path': dest_path.full_path.rstrip('/')
         }
-        aiohttpretty.register_json_uri('POST', url, **{
-            "responses": [
-                {
+        conflict_response = {
                     'headers': {'Content-Type': 'application/json'},
                     'data': data,
                     'body': json.dumps(error_fixtures['rename_conflict_file_metadata']).encode('utf-8'),
                     'status': HTTPStatus.CONFLICT
-                },
+                }
+        aiohttpretty.register_json_uri('POST', url, **{
+            "responses": [
+                conflict_response,
+                conflict_response,
+                conflict_response,
+                conflict_response,
+                conflict_response,
+                conflict_response,
                 {
                     'headers': {'Content-Type': 'application/json'},
                     'data': data,

--- a/tests/server/api/v1/test_movecopy.py
+++ b/tests/server/api/v1/test_movecopy.py
@@ -75,12 +75,15 @@ class TestMoveOrCopy:
                                               handler.auth['settings'])
         handler.write.assert_called_with(serialized_metadata)
         assert handler.dest_meta == mock_file_metadata
+        kwargs = {}
+        if action == 'copy':
+            kwargs = {'version': None}
         mock_celery.assert_called_with(celery_src_copy_params,
                                        celery_dest_copy_params,
                                        conflict='warn',
                                        rename=None,
-                                       version=None,
-                                       request=serialized_request)
+                                       request=serialized_request,
+                                       **kwargs)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('action', ['move', 'copy'])
@@ -151,5 +154,4 @@ class TestMoveOrCopy:
                                        celery_dest_copy_params_root,
                                        conflict='warn',
                                        rename='renamed path',
-                                       version=None,
                                        request=serialized_request)

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -325,7 +325,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
                 else:
                     raise exceptions.WaterButlerError('Unsupported HTTP method ...')
                 self.provider_metrics.incr('requests.tally.ok')
-                if response.status in force_retry_on or (expects and response.status not in expects):
+                if (retry > 0 and response.status in force_retry_on) or (expects and response.status not in expects):
                     unexpected = await exceptions.exception_from_response(response,
                                                                           error=throws, **kwargs)
                     raise unexpected

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -25,6 +25,7 @@ from waterbutler.core.utils import RequestHandlerContext
 
 logger = logging.getLogger(__name__)
 _THROTTLES = weakref.WeakKeyDictionary()  # type: weakref.WeakKeyDictionary
+NO_URL_ENCODED_PROVIDERS = ['nextcloud', 'owncloud', 'nextcloudinstitutions']
 
 
 def throttle(concurrency=10, interval=1):
@@ -287,7 +288,9 @@ class BaseProvider(metaclass=abc.ABCMeta):
         while retry >= 0:
             # Don't overwrite the callable ``url`` so that signed URLs are refreshed for every retry
             non_callable_url = url() if callable(url) else url
-            non_callable_url = URL(non_callable_url, encoded=True)
+            if self.NAME not in NO_URL_ENCODED_PROVIDERS:
+                # Fix storage 'nextcloud', 'owncloud', 'nextcloudinstitutions' return HTTP 400 bad request
+                non_callable_url = URL(non_callable_url, encoded=True)
             try:
                 self.provider_metrics.incr('requests.count')
                 # TODO: use a `dict` to select methods with either `lambda` or `functools.partial`

--- a/waterbutler/providers/dropbox/settings.py
+++ b/waterbutler/providers/dropbox/settings.py
@@ -10,3 +10,5 @@ BASE_CONTENT_URL = config.get('BASE_CONTENT_URL', 'https://content.dropboxapi.co
 CONTIGUOUS_UPLOAD_SIZE_LIMIT = int(config.get('CONTIGUOUS_UPLOAD_SIZE_LIMIT', 150000000))  # 150 MB
 
 CHUNK_SIZE = int(config.get('CHUNK_SIZE', 4000000))  # 4 MB
+
+RETRY = 5

--- a/waterbutler/providers/dropbox/settings.py
+++ b/waterbutler/providers/dropbox/settings.py
@@ -11,4 +11,7 @@ CONTIGUOUS_UPLOAD_SIZE_LIMIT = int(config.get('CONTIGUOUS_UPLOAD_SIZE_LIMIT', 15
 
 CHUNK_SIZE = int(config.get('CHUNK_SIZE', 4000000))  # 4 MB
 
+# An optional integer specifying the number of failed requests retries for a simple Dropbox API call.
+# Specify usage for `DropboxProvider.dropbox_request()` and `BaseProvider.make_request()` usages
+# in the DropboxProvider and DropboxBusinessProvider
 RETRY = 5

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -147,12 +147,16 @@ class MoveCopyMixin:
         if not getattr(self.provider, 'can_intra_' + provider_action)(self.dest_provider, self.path):
             # this weird signature syntax courtesy of py3.4 not liking trailing commas on kwargs
             conflict = self.json.get('conflict', DEFAULT_CONFLICT)
+            task_kwargs = {}
+            if provider_action == 'copy':
+                # Only copy API has additional 'version' argument
+                task_kwargs = {'version': self.requested_version}
             result = await getattr(tasks, provider_action).adelay(
                 rename=self.json.get('rename'),
                 conflict=conflict,
-                version=self.requested_version,
                 request=remote_logging._serialize_request(self.request),
-                *self.build_args()
+                *self.build_args(),
+                **task_kwargs,
             )
             metadata, created = await tasks.wait_on_celery(result)
         else:


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

Relate to the following issue:

NII Redmine#38466

## Purpose

* Some necessary changes and use of the retry handling support for a simple Dropbox API call in the DropboxProvider and DropboxBusinessProvider.

## Changes

  * No DB changes
  * `waterbutler.core.provider.BaseProvider.make_request`
  * `waterbutler.providers.dropbox.provider.DropboxProvider`
## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
