### PR TITLE
Improve S3Compat Provider implementation.

### DIFF
--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -92,7 +92,7 @@ def file_header_metadata():
         'Content-Length': '9001',
         'Last-Modified': 'SomeTime',
         'Content-Type': 'binary/octet-stream',
-        'ETag': '"fba9dede5f27731c9771645a39863328"',
+        'Etag': '"fba9dede5f27731c9771645a39863328"',
         'x-amz-server-side-encryption': 'AES256'
     }
 

--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -92,7 +92,7 @@ def file_header_metadata():
         'Content-Length': '9001',
         'Last-Modified': 'SomeTime',
         'Content-Type': 'binary/octet-stream',
-        'Etag': '"fba9dede5f27731c9771645a39863328"',
+        'ETag': '"fba9dede5f27731c9771645a39863328"',
         'x-amz-server-side-encryption': 'AES256'
     }
 

--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -150,6 +150,30 @@ def revision_metadata_object():
 
 
 @pytest.fixture
+def copy_object_resp():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <CopyObjectResult>
+        <ETag>string</ETag>
+        <LastModified>timestamp</LastModified>
+        <ChecksumCRC32>string</ChecksumCRC32>
+        <ChecksumCRC32C>string</ChecksumCRC32C>
+        <ChecksumSHA1>string</ChecksumSHA1>
+        <ChecksumSHA256>string</ChecksumSHA256>
+    </CopyObjectResult>'''
+
+
+@pytest.fixture
+def api_error_resp():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <Error>
+        <Code>Internal Error</Code>
+        <Message>Internal Error</Message>
+        <Resource>/object/path</Resource>
+        <RequestId>1234567890</RequestId>
+    </Error>'''
+
+
+@pytest.fixture
 def single_version_metadata():
     return '''<?xml version="1.0" encoding="UTF-8"?>
     <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
@@ -1223,6 +1247,53 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_chunked_upload_complete_multipart_upload_error(self, provider,
+                                                            upload_parts_headers_list,
+                                                            api_error_resp, mock_time):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        payload = '<?xml version="1.0" encoding="UTF-8"?>'
+        payload += '<CompleteMultipartUpload>'
+        # aiohttp resp headers are upper case
+        headers_list = json.loads(upload_parts_headers_list).get('headers_list')
+        headers_list = [{k.upper(): v for k, v in headers.items()} for headers in headers_list]
+        for i, part in enumerate(headers_list):
+            payload += '<Part>'
+            payload += '<PartNumber>{}</PartNumber>'.format(i+1)  # part number must be >= 1
+            payload += '<ETag>{}</ETag>'.format(xml.sax.saxutils.escape(part['ETAG']))
+            payload += '</Part>'
+        payload += '</CompleteMultipartUpload>'
+        payload = payload.encode('utf-8')
+
+        headers = {
+            'Content-Length': str(len(payload)),
+            'Content-MD5': compute_md5(BytesIO(payload))[1],
+            'Content-Type': 'text/xml',
+        }
+
+        complete_url = provider.bucket.new_key(path.full_path).generate_url(
+            100,
+            'POST',
+            headers=headers,
+            query_parameters=params
+        )
+
+        aiohttpretty.register_uri(
+            'POST',
+            complete_url,
+            status=200,
+            body=api_error_resp
+        )
+
+        with pytest.raises(exceptions.UploadError):
+            await provider._complete_multipart_upload(path, upload_id, headers_list)
+
+        assert aiohttpretty.has_call(method='POST', uri=complete_url, params=params)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_abort_chunked_upload_session_deleted(self, provider, generic_http_404_resp,
                                                         mock_time):
         path = WaterButlerPath('/foobah', prepend=provider.prefix)
@@ -1796,7 +1867,7 @@ class TestOperations:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_intra_copy(self, provider, file_header_metadata, mock_time):
+    async def test_intra_copy(self, provider, file_header_metadata, copy_object_resp, mock_time):
         dest_path = WaterButlerPath('/dest', prepend=provider.prefix)
         source_path = WaterButlerPath('/source', prepend=provider.prefix)
 
@@ -1806,12 +1877,32 @@ class TestOperations:
         header_path = '/' + os.path.join(provider.settings['bucket'], source_path.full_path)
         headers = {'x-amz-copy-source': parse.quote(header_path)}
         url = provider.bucket.new_key(dest_path.full_path).generate_url(100, 'PUT', headers=headers)
-        aiohttpretty.register_uri('PUT', url, status=200)
+        aiohttpretty.register_uri('PUT', url, status=200, body=copy_object_resp, auto_length=True)
 
         metadata, exists = await provider.intra_copy(provider, source_path, dest_path)
 
         assert metadata.kind == 'file'
         assert not exists
+        assert aiohttpretty.has_call(method='HEAD', uri=metadata_url)
+        assert aiohttpretty.has_call(method='PUT', uri=url, headers=headers)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_copy_error(self, provider, file_header_metadata, api_error_resp, mock_time):
+        dest_path = WaterButlerPath('/dest', prepend=provider.prefix)
+        source_path = WaterButlerPath('/source', prepend=provider.prefix)
+
+        metadata_url = provider.bucket.new_key(dest_path.full_path).generate_url(100, 'HEAD')
+        aiohttpretty.register_uri('HEAD', metadata_url, headers=file_header_metadata)
+
+        header_path = '/' + os.path.join(provider.settings['bucket'], source_path.full_path)
+        headers = {'x-amz-copy-source': parse.quote(header_path)}
+        url = provider.bucket.new_key(dest_path.full_path).generate_url(100, 'PUT', headers=headers)
+        aiohttpretty.register_uri('PUT', url, status=200, body=api_error_resp, auto_length=True)
+
+        with pytest.raises(exceptions.IntraCopyError):
+            metadata, exists = await provider.intra_copy(provider, source_path, dest_path)
+
         assert aiohttpretty.has_call(method='HEAD', uri=metadata_url)
         assert aiohttpretty.has_call(method='PUT', uri=url, headers=headers)
 

--- a/tests/providers/s3compatinstitutions/test_provider.py
+++ b/tests/providers/s3compatinstitutions/test_provider.py
@@ -22,6 +22,8 @@ from tests.providers.s3compat.test_provider import (
     folder_key_metadata_object,
     folder_metadata_object,
     revision_metadata_object,
+    copy_object_resp,
+    api_error_resp,
     single_version_metadata,
     version_metadata,
     folder_and_contents,

--- a/waterbutler/providers/s3compat/metadata.py
+++ b/waterbutler/providers/s3compat/metadata.py
@@ -51,12 +51,12 @@ class S3CompatFileMetadataHeaders(S3CompatMetadata, metadata.BaseFileMetadata):
 
     @property
     def etag(self):
-        return self.raw['ETag'].replace('"', '')
+        return self.raw['Etag'].replace('"', '')
 
     @property
     def extra(self):
         return {
-            'md5': self.raw['ETag'].replace('"', ''),
+            'md5': self.raw['Etag'].replace('"', ''),
             'encryption': self.raw.get('x-amz-server-side-encryption', '')
         }
 

--- a/waterbutler/providers/s3compat/metadata.py
+++ b/waterbutler/providers/s3compat/metadata.py
@@ -51,12 +51,12 @@ class S3CompatFileMetadataHeaders(S3CompatMetadata, metadata.BaseFileMetadata):
 
     @property
     def etag(self):
-        return self.raw['Etag'].replace('"', '')
+        return self.raw['ETag'].replace('"', '')
 
     @property
     def extra(self):
         return {
-            'md5': self.raw['Etag'].replace('"', ''),
+            'md5': self.raw['ETag'].replace('"', ''),
             'encryption': self.raw.get('x-amz-server-side-encryption', '')
         }
 

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -234,6 +234,7 @@ class S3CompatProvider(provider.BaseProvider):
                     pre_size = e - s + 1
         except exceptions.MetadataError:
             pre_size = None
+            pre_etag = None
 
         if not revision or revision.lower() == 'latest':
             query_parameters = None

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -319,7 +319,7 @@ class S3CompatProvider(provider.BaseProvider):
             upload_url,
             headers=headers,
             skip_auto_headers={'CONTENT-TYPE'},
-            params=params,
+            # params=params,
             expects=(200, 201,),
             throws=exceptions.UploadError,
         )
@@ -369,7 +369,7 @@ class S3CompatProvider(provider.BaseProvider):
             data=cutoff_stream,
             skip_auto_headers={'CONTENT-TYPE'},
             headers=headers,
-            params=params,
+            # params=params,
             expects=(200, 201,),
             throws=exceptions.UploadError,
         )
@@ -515,7 +515,7 @@ class S3CompatProvider(provider.BaseProvider):
             complete_url,
             data=payload,
             headers=headers,
-            params=params,
+            # params=params,
             expects=(200, 201,),
             throws=exceptions.UploadError,
         )


### PR DESCRIPTION
## Ticket

NA

## Purpose

Improving compliance with the S3/HTTP API.

## Changes

- Fix issue of duplicated HTTP query parameters
  - The fix ensures that each parameter is only included once in the query string.
  - This change affects the following three API calls:
     - CreateMultipartUpload API
     - UploadPart API
     - CompleteMultipartUpload API.
- Added handling for cases where the HTTP response header does not return a Content-Length.
  - Implemented a combination of size retrieval through HEAD Requests and GET.
- Modified response body handling for certain S3 APIs.
  - Due to the specifications of the S3 API, it is necessary to check for errors in the response body after receiving a 200 OK HTTP Status.
  - In this commit, the handling of the following two APIs has been corrected:
    - CopyObject
    - CompleteMultipartUpload

- Fixed imports for S3CompatInstitutions tests.
  - Necessary fixtures were not imported as these tests are reusing S3Compat tests.
- Fixed error that occurred when failing to fetch metadata before downloading.

These commit are reverted. please ignore these.

- Revert "Corrected 'Etag' to the proper casing 'ETag'."
- Corrected 'Etag' to the proper casing 'ETag'.

## Side effects

- There's no need to add duplicate query parameters. I believe there will be no impact.
- Changes regarding the `Content-Length` will increase the number of API calls as we will fetch the file's metadata just before the object's download. If metadata retrieval fails, the operation will proceed as before.
- I've improved error handling of some APIs, but there could be impacts if the behavior during an error differs from what's defined in the S3 Protocol.
- [In the Provider's download interface, the version parameter is allowed.](https://github.com/RCOSDP/RDM-waterbutler/pull/59/commits/e9f33ae404f983c862f8fca2cb6efc6f9aa6bc4e#diff-a8adac5f7589e0e74f8bbb98598156a37510d0e36a46a089b7b05b1fcc60a2aaR193-R195)

Note: In the S3Compat implementation, I think there is some confusion about the names 'revision' and 'version'. This affects the versionId query parameter in the S3 API. In the download interface of the s3compat driver, it is defined by the 'revision' parameter. However, there seem to be several places where the 'version' kwargs are given when this is actually called. The abstract class in core uses the 'version' kwargs.

I thought this might be a bug, but I haven't made any changes to unify the caller. This is due to two things: it's unclear which is the correct interface, 'revision' or 'version', and the impact of unifying to either 'revision' or 'version' is unknown.

In the test_download_version test case in tests/providers/s3compat/test_provider.py, the 'version' kwargs were used. Whether the versionId was passed as a query parameter was not checked before the changes in this Pull Request.

However, since this appears as a problem in the verification of the Signed URL used to retrieve metadata, in this PR, I have added a mitigation process that enables 'version' only when 'revision' is not specified.

## QA Notes

I have added some test cases, but the results of the RDM-waterbutler test (`invoke test`) are no different from before the patch.

I have also tested the changes with the object storage software I have it locally. However, this is limited to operations from the web UI provided by RDM-osf.io. I believe I have covered all the changes, but I have not checked the entire functionality provided by RDM-waterbutler.

## Deployment Notes

Nothing.

## Additional Notes

This PR is the result of my personal activities. The code included in the PR is a contribution to the project, and I will not make any claims of rights regarding these changes. Also, I will not assume any obligations.
I hope this patch is reviewed as something of value and merged.