### PR TITLE
Feature/grdm 202403 step3/2.1.4 remove file operation restriction nextcloud for institution

### DIFF
--- a/tests/core/test_provider.py
+++ b/tests/core/test_provider.py
@@ -1,10 +1,12 @@
+from asyncio import StreamReader
+from io import BytesIO
 import pytest
 
 from tests import utils
 from unittest import mock
 from waterbutler.core import metadata
 from waterbutler.core import exceptions
-
+from tests.core.streams.fixtures import mock_response_stream_reader
 
 @pytest.fixture
 def provider1():
@@ -331,6 +333,87 @@ class TestCopy:
         assert ret == 'Upload return'
         provider1.download.assert_called_once_with(src_path, version=None)
         provider1.upload.assert_called_once_with('Download return', dest_path)
+
+    @pytest.mark.asyncio
+    async def test_file_size_when_copy_file_download_is_gzip_before_upload(self, provider1, mock_response_stream_reader):
+        src_path = await provider1.validate_path('/source/path')
+        dest_path = await provider1.validate_path('/destination/path')
+        mock_response_stream_reader.response.headers['Content-Encoding'] = 'gzip'
+        mock_response_stream_reader.response.headers['Content-Length'] = '200'
+        stream_reader = StreamReader()
+        byte_stream = BytesIO(b'data')
+        stream_reader.feed_data(byte_stream.read())
+        stream_reader.feed_eof()
+        mock_response_stream_reader.response.content = stream_reader
+        provider1.upload = utils.MockCoroutine(return_value='Upload return')
+        provider1.download = utils.MockCoroutine(return_value=mock_response_stream_reader)
+
+        await provider1.copy(provider1, src_path, dest_path)
+
+        assert mock_response_stream_reader.size != mock_response_stream_reader.response.headers['Content-Length']
+        provider1.download.assert_called_once_with(src_path, version=None)
+
+    @pytest.mark.asyncio
+    async def test_file_size_when_copy_file_download_is_chunked_before_upload(self, provider1, mock_response_stream_reader):
+        src_path = await provider1.validate_path('/source/path')
+        dest_path = await provider1.validate_path('/destination/path')
+        mock_response_stream_reader.response.headers['Transfer-Encoding'] = 'chunked'
+        mock_response_stream_reader.response.headers['Content-Length'] = '200'
+        stream_reader = StreamReader()
+        byte_stream = BytesIO(b'data')
+        stream_reader.feed_data(byte_stream.read())
+        stream_reader.feed_eof()
+        mock_response_stream_reader.response.content = stream_reader
+        provider1.upload = utils.MockCoroutine(return_value='Upload return')
+        provider1.download = utils.MockCoroutine(return_value=mock_response_stream_reader)
+
+        await provider1.copy(provider1, src_path, dest_path)
+
+        assert mock_response_stream_reader.size != mock_response_stream_reader.response.headers['Content-Length']
+        provider1.download.assert_called_once_with(src_path, version=None)
+
+    @pytest.mark.asyncio
+    async def test_file_size_when_copy_file_download_is_gzip_and_bytes_downloaded_is_none_before_upload(self, provider1,
+                                                                              mock_response_stream_reader):
+        src_path = await provider1.validate_path('/source/path')
+        dest_path = await provider1.validate_path('/destination/path')
+        mock_response_stream_reader.response.headers['Content-Encoding'] = 'gzip'
+        mock_response_stream_reader.response.headers['Content-Length'] = '200'
+        stream_reader = StreamReader()
+        byte_stream = BytesIO(b'')
+        stream_reader.feed_data(byte_stream.read())
+        stream_reader.feed_eof()
+        mock_response_stream_reader.response.content = stream_reader
+        provider1.bytes_downloaded = None
+        provider1.upload = utils.MockCoroutine(return_value='Upload return')
+        provider1.download = utils.MockCoroutine(return_value=mock_response_stream_reader)
+
+        await provider1.copy(provider1, src_path, dest_path)
+
+        assert mock_response_stream_reader.size == int(mock_response_stream_reader.response.headers['Content-Length'])
+        provider1.download.assert_called_once_with(src_path, version=None)
+
+
+    @pytest.mark.asyncio
+    async def test_file_size_when_copy_file_download_is_chunked_and_bytes_downloaded_is_none_before_upload(self, provider1,
+                                                                              mock_response_stream_reader):
+        src_path = await provider1.validate_path('/source/path')
+        dest_path = await provider1.validate_path('/destination/path')
+        mock_response_stream_reader.response.headers['Transfer-Encoding'] = 'chunked'
+        mock_response_stream_reader.response.headers['Content-Length'] = '200'
+        stream_reader = StreamReader()
+        byte_stream = BytesIO(b'')
+        stream_reader.feed_data(byte_stream.read())
+        stream_reader.feed_eof()
+        mock_response_stream_reader.response.content = stream_reader
+        provider1.bytes_downloaded = None
+        provider1.upload = utils.MockCoroutine(return_value='Upload return')
+        provider1.download = utils.MockCoroutine(return_value=mock_response_stream_reader)
+
+        await provider1.copy(provider1, src_path, dest_path)
+
+        assert mock_response_stream_reader.size == int(mock_response_stream_reader.response.headers['Content-Length'])
+        provider1.download.assert_called_once_with(src_path, version=None)
 
 
 class TestMove:

--- a/tests/core/test_provider.py
+++ b/tests/core/test_provider.py
@@ -339,7 +339,7 @@ class TestCopy:
         src_path = await provider1.validate_path('/source/path')
         dest_path = await provider1.validate_path('/destination/path')
         mock_response_stream_reader.response.headers['Content-Encoding'] = 'gzip'
-        mock_response_stream_reader.response.headers['Content-Length'] = '200'
+        mock_response_stream_reader.response.headers['Content-Length'] = '100'
         stream_reader = StreamReader()
         byte_stream = BytesIO(b'data')
         stream_reader.feed_data(byte_stream.read())
@@ -358,7 +358,7 @@ class TestCopy:
         src_path = await provider1.validate_path('/source/path')
         dest_path = await provider1.validate_path('/destination/path')
         mock_response_stream_reader.response.headers['Transfer-Encoding'] = 'chunked'
-        mock_response_stream_reader.response.headers['Content-Length'] = '200'
+        mock_response_stream_reader.response.headers['Content-Length'] = '100'
         stream_reader = StreamReader()
         byte_stream = BytesIO(b'data')
         stream_reader.feed_data(byte_stream.read())
@@ -378,7 +378,7 @@ class TestCopy:
         src_path = await provider1.validate_path('/source/path')
         dest_path = await provider1.validate_path('/destination/path')
         mock_response_stream_reader.response.headers['Content-Encoding'] = 'gzip'
-        mock_response_stream_reader.response.headers['Content-Length'] = '200'
+        mock_response_stream_reader.response.headers['Content-Length'] = '100'
         stream_reader = StreamReader()
         byte_stream = BytesIO(b'')
         stream_reader.feed_data(byte_stream.read())
@@ -400,7 +400,7 @@ class TestCopy:
         src_path = await provider1.validate_path('/source/path')
         dest_path = await provider1.validate_path('/destination/path')
         mock_response_stream_reader.response.headers['Transfer-Encoding'] = 'chunked'
-        mock_response_stream_reader.response.headers['Content-Length'] = '200'
+        mock_response_stream_reader.response.headers['Content-Length'] = '100'
         stream_reader = StreamReader()
         byte_stream = BytesIO(b'')
         stream_reader.feed_data(byte_stream.read())

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -6,9 +6,6 @@ import logging
 import weakref
 import functools
 import itertools
-from asyncio import StreamReader
-from io import BytesIO
-import tornado.iostream
 from urllib import parse
 
 import furl
@@ -22,10 +19,8 @@ from waterbutler.core import path as wb_path
 from waterbutler import settings as wb_settings
 from waterbutler.core.metrics import MetricsRecord
 from waterbutler.core import metadata as wb_metadata
-from waterbutler.core.streams import ResponseStreamReader
 from waterbutler.core.utils import ZipStreamGenerator
 from waterbutler.core.utils import RequestHandlerContext
-from waterbutler.server import settings
 
 
 logger = logging.getLogger(__name__)
@@ -78,20 +73,6 @@ def build_url(base, *segments, **query):
     return url.url
 
 
-def bytes_to_response_content(byte_data):
-    """
-    Convert content from byte to StreamReader
-    :param byte_data: ( :class:`bytes` ) data type bytes
-    """
-    stream_reader = StreamReader()
-    if isinstance(byte_data, bytes):
-        byte_stream = BytesIO(byte_data)
-        stream_reader.feed_data(byte_stream.read())
-        stream_reader.feed_eof()
-
-    return stream_reader
-
-
 class BaseProvider(metaclass=abc.ABCMeta):
     """The base class for all providers. Every provider must, at the least, implement all abstract
     methods in this class.
@@ -105,8 +86,6 @@ class BaseProvider(metaclass=abc.ABCMeta):
     """
 
     BASE_URL = None
-
-    bytes_downloaded = 0
 
     def __init__(self, auth: dict,
                  credentials: dict,
@@ -470,24 +449,12 @@ class BaseProvider(metaclass=abc.ABCMeta):
             return await self._folder_file_op(self.copy, *args, **kwargs)  # type: ignore
 
         download_stream = await self.download(src_path, version=version)
-        is_compression = is_chunked = False
-        if isinstance(download_stream, ResponseStreamReader):
-            is_compression = 'gzip' in download_stream.response.headers.get('Content-Encoding', '')
-            is_chunked = 'chunked' in download_stream.response.headers.get('Transfer-Encoding', '')
-
-        if is_chunked or is_compression:
-            content = await self.clone_content_in_response(download_stream.response)
-            download_stream.response.content = bytes_to_response_content(content)
 
         if getattr(download_stream, 'name', None):
             dest_path.rename(download_stream.name)
 
         if hasattr(download_stream, '_size') and download_stream._size is None:
             download_stream._size = 0
-
-        # update response headers by the original size after decompressing
-        if (is_chunked or is_compression) and self.bytes_downloaded is not None:
-            download_stream._size = self.bytes_downloaded
 
         return await dest_provider.upload(download_stream, dest_path)
 
@@ -898,25 +865,3 @@ class BaseProvider(metaclass=abc.ABCMeta):
     def __repr__(self):
         # Note: credentials are not included on purpose.
         return '<{}({}, {})>'.format(self.__class__.__name__, self.auth, self.settings)
-
-    async def clone_content_in_response(self, response):
-        """
-        Clone content in response
-        :param response: ( :class:`StreamReader` ) the response in ResponseStreamReader
-        """
-        content = response.content
-        chunk_list = []
-        try:
-            while True:
-                chunk = await content.read(settings.CHUNK_SIZE)
-                if not chunk:
-                    # Return a content type bytes
-                    return b"".join(chunk_list)
-                if isinstance(chunk, bytearray):
-                    chunk = bytes(chunk)
-                self.bytes_downloaded += len(chunk)
-                chunk_list.append(chunk)
-        except tornado.iostream.StreamClosedError:
-            # Client has disconnected early.
-            # No need for any exception to be raised
-            return


### PR DESCRIPTION
## Purpose

Error "Calculated and received hashes don't match" when move file from Nextcloud for Institutions Storage to S3 Compatible Storage

## Changes

Update 'Content-Length' when response header is 'gzip' or 'chunked'

## Documentation

None

## Side Effects

None

## Ticket

2.1.4.Nextcloud for InstitutionsからS3 Compatible Storageへのファイル操作制限解除