### PR TITLE
Feature/grdm 202403 step3/2.1.5 remove restriction move file to parent project

### DIFF
--- a/tests/providers/dropbox/fixtures/root_provider.json
+++ b/tests/providers/dropbox/fixtures/root_provider.json
@@ -136,8 +136,8 @@
       "server_modified":"2015-05-12T15:50:38Z",
       "rev":"a1c10ce0dd78",
       "size":7212,
-      "path_lower":"/homework/math/prime_numbers.txt",
-      "path_display":"/Homework/math/Prime_Numbers.txt",
+      "path_lower":"/pfile_renamed/prime_numbers.txt",
+      "path_display":"/pfile_renamed/Prime_Numbers.txt",
       "sharing_info":{
         "read_only":true,
         "parent_shared_folder_id":"84528192421",
@@ -158,6 +158,68 @@
       "content_hash":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     }
   },
+  "intra_move_copy_get_current_account":{
+    "account_id": "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc",
+    "account_type": {
+        ".tag": "business"
+    },
+    "country": "US",
+    "disabled": false,
+    "email": "franz@dropbox.com",
+    "email_verified": true,
+    "is_paired": true,
+    "locale": "en",
+    "name": {
+        "abbreviated_name": "FF",
+        "display_name": "Franz Ferdinand (Personal)",
+        "familiar_name": "Franz",
+        "given_name": "Franz",
+        "surname": "Ferdinand"
+    },
+    "referral_link": "https://db.tt/ZITNuhtI",
+    "root_info": {
+        ".tag": "user",
+        "home_namespace_id": "3235641",
+        "root_namespace_id": "3235641"
+    },
+    "team": {
+        "id": "dbtid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I",
+        "name": "Acme, Inc.",
+        "office_addin_policy": {
+            ".tag": "disabled"
+        },
+        "sharing_policies": {
+            "default_link_expiration_days_policy": {
+                ".tag": "none"
+            },
+            "enforce_link_password_policy": {
+                ".tag": "optional"
+            },
+            "group_creation_policy": {
+                ".tag": "admins_only"
+            },
+            "shared_folder_join_policy": {
+                ".tag": "from_anyone"
+            },
+            "shared_folder_link_restriction_policy": {
+                ".tag": "anyone"
+            },
+            "shared_folder_member_policy": {
+                ".tag": "team"
+            },
+            "shared_link_create_policy": {
+                ".tag": "team_only"
+            },
+            "shared_link_default_permissions_policy": {
+                ".tag": "default"
+            }
+        },
+        "top_level_content_policy": {
+            ".tag": "admin_only"
+        }
+    },
+    "team_member_id": "dbmid:AAHhy7WsR0x-u4ZCqiDl5Fz5zvuL3kmspwU"
+},
   "intra_move_copy_folder_metadata_v2":{
     "metadata":{
       ".tag":"folder",
@@ -167,8 +229,8 @@
       "server_modified":"2015-05-12T15:50:38Z",
       "rev":"a1c10ce0dd78",
       "size":7212,
-      "path_lower":"/testfolder/",
-      "path_display":"/Test Folder/",
+      "path_lower":"/photos/pfile_renamed",
+      "path_display":"/Photos/pfile_renamed",
       "sharing_info":{
         "read_only":true,
         "parent_shared_folder_id":"84528192421",

--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -750,8 +750,52 @@ class TestIntraMoveCopy:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_copy_file(self, provider, provider_fixtures):
-        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
-        dest_path = WaterButlerPath('/pfile_renamed', prepend=provider.folder)
+        url_get_current_account = provider.build_url('users', 'get_current_account')
+        aiohttpretty.register_json_uri(
+            'POST',
+            url_get_current_account,
+            data=None,
+            body=provider_fixtures['intra_move_copy_get_current_account']
+        )
+        provider.team_folder_name = 'provider_team_folder_name'
+        src_path = WaterButlerPath('/pfile/Prime_Numbers.txt', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed/Prime_Numbers.txt', prepend=provider.folder)
+
+        url = provider.build_url('files', 'copy_v2')
+        data = {
+            'from_path': src_path.full_path.rstrip('/'),
+            'to_path': dest_path.full_path.rstrip('/')
+        },
+        aiohttpretty.register_json_uri(
+            'POST',
+            url,
+            data=data,
+            body=provider_fixtures['intra_move_copy_file_metadata_v2']
+        )
+
+        result = await provider.intra_copy(provider, src_path, dest_path)
+        expected = (
+            DropboxFileMetadata(
+                provider_fixtures['intra_move_copy_file_metadata_v2']['metadata'],
+                provider.folder, provider.NAME
+            ),
+            True
+        )
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_copy_file_without_team_folder_name(self, provider, provider_fixtures):
+        url_get_current_account = provider.build_url('users', 'get_current_account')
+        aiohttpretty.register_json_uri(
+            'POST',
+            url_get_current_account,
+            data=None,
+            body=provider_fixtures['intra_move_copy_get_current_account']
+        )
+        src_path = WaterButlerPath('/pfile/Prime_Numbers.txt', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed/Prime_Numbers.txt', prepend=provider.folder)
 
         url = provider.build_url('files', 'copy_v2')
         data = {
@@ -784,13 +828,21 @@ class TestIntraMoveCopy:
             provider_fixtures,
             error_fixtures
     ):
+        url_get_current_account = provider.build_url('users', 'get_current_account')
+        aiohttpretty.register_json_uri(
+            'POST',
+            url_get_current_account,
+            data=None,
+            body=provider_fixtures['intra_move_copy_get_current_account']
+        )
         url = provider.build_url('files', 'delete_v2')
         path = await provider.validate_path('/The past')
         data = {'path': path.full_path}
         aiohttpretty.register_json_uri('POST', url, data=data, status=HTTPStatus.OK)
 
-        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
-        dest_path = WaterButlerPath('/pfile_renamed', prepend=provider.folder)
+        provider.team_folder_name = 'provider_team_folder_name'
+        src_path = WaterButlerPath('/pfile/Prime_Numbers.txt', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed/Prime_Numbers.txt', prepend=provider.folder)
 
         url = provider.build_url('files', 'copy_v2')
         data = {
@@ -874,6 +926,15 @@ class TestIntraMoveCopy:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_copy_folder(self, provider, provider_fixtures):
+        url_get_current_account = provider.build_url('users', 'get_current_account')
+        aiohttpretty.register_json_uri(
+            'POST',
+            url_get_current_account,
+            data=None,
+            body=provider_fixtures['intra_move_copy_get_current_account']
+        )
+
+        provider.team_folder_name = 'provider_team_folder_name'
         src_path = WaterButlerPath('/pfile/', prepend=provider.folder)
         dest_path = WaterButlerPath('/pfile_renamed/', prepend=provider.folder)
 
@@ -914,10 +975,54 @@ class TestIntraMoveCopy:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_move_file(self, provider, provider_fixtures):
-        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
-        dest_path = WaterButlerPath('/pfile_renamed', prepend=provider.folder)
+        provider.team_folder_name = 'provider_team_folder_name'
+        src_path = WaterButlerPath('/pfile/Prime_Numbers.txt', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed/Prime_Numbers.txt', prepend=provider.folder)
 
         url = provider.build_url('files', 'move_v2')
+        url_get_current_account = provider.build_url('users', 'get_current_account')
+        aiohttpretty.register_json_uri(
+            'POST',
+            url_get_current_account,
+            data=None,
+            body=provider_fixtures['intra_move_copy_get_current_account']
+        )
+        data = {
+            'from_path': src_path.full_path.rstrip('/'),
+            'to_path': dest_path.full_path.rstrip('/')
+        }
+        aiohttpretty.register_json_uri(
+            'POST',
+            url,
+            data=data,
+            body=provider_fixtures['intra_move_copy_file_metadata_v2']
+        )
+
+        result = await provider.intra_move(provider, src_path, dest_path)
+        expected = (
+            DropboxFileMetadata(
+                provider_fixtures['intra_move_copy_file_metadata_v2']['metadata'],
+                provider.folder, provider.NAME
+            ),
+            True
+        )
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_move_file_without_team_folder_name(self, provider, provider_fixtures):
+        src_path = WaterButlerPath('/pfile/Prime_Numbers.txt', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed/Prime_Numbers.txt', prepend=provider.folder)
+
+        url = provider.build_url('files', 'move_v2')
+        url_get_current_account = provider.build_url('users', 'get_current_account')
+        aiohttpretty.register_json_uri(
+            'POST',
+            url_get_current_account,
+            data=None,
+            body=provider_fixtures['intra_move_copy_get_current_account']
+        )
         data = {
             'from_path': src_path.full_path.rstrip('/'),
             'to_path': dest_path.full_path.rstrip('/')
@@ -943,13 +1048,21 @@ class TestIntraMoveCopy:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_move_replace_file(self, provider, provider_fixtures, error_fixtures):
+        url_get_current_account = provider.build_url('users', 'get_current_account')
+        aiohttpretty.register_json_uri(
+            'POST',
+            url_get_current_account,
+            data=None,
+            body=provider_fixtures['intra_move_copy_get_current_account']
+        )
         url = provider.build_url('files', 'delete_v2')
         path = await provider.validate_path('/The past')
         data = {'path': path.full_path}
         aiohttpretty.register_json_uri('POST', url, data=data, status=HTTPStatus.OK)
 
-        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
-        dest_path = WaterButlerPath('/pfile_renamed', prepend=provider.folder)
+        provider.team_folder_name = 'provider_team_folder_name'
+        src_path = WaterButlerPath('/pfile/Prime_Numbers.txt', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed/Prime_Numbers.txt', prepend=provider.folder)
 
         url = provider.build_url('files', 'move_v2')
         data = {
@@ -993,6 +1106,14 @@ class TestIntraMoveCopy:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_move_replace_folder(self, provider, provider_fixtures, error_fixtures):
+        url_get_current_account = provider.build_url('users', 'get_current_account')
+        aiohttpretty.register_json_uri(
+            'POST',
+            url_get_current_account,
+            data=None,
+            body=provider_fixtures['intra_move_copy_get_current_account']
+        )
+
         url = provider.build_url('files', 'delete_v2')
         path = await provider.validate_path('/newfolder/')
         data = {'path': path.full_path}
@@ -1008,6 +1129,7 @@ class TestIntraMoveCopy:
             status=HTTPStatus.OK
         )
 
+        provider.team_folder_name = 'provider_team_folder_name'
         src_path = WaterButlerPath('/pfile/', prepend=provider.folder)
         dest_path = WaterButlerPath('/pfile_renamed/', prepend=provider.folder)
 

--- a/tests/providers/dropboxbusiness/fixtures.py
+++ b/tests/providers/dropboxbusiness/fixtures.py
@@ -7,14 +7,16 @@ from waterbutler.providers.dropboxbusiness import DropboxBusinessProvider
 def settings():
     return {'folder': '/Photos',
             'admin_dbmid': 'dbmid:dummy',
-            'team_folder_id': '1234567890'}
+            'team_folder_id': '1234567890',
+            'team_folder_name': 'team_folder_name'}
 
 
 @pytest.fixture
 def settings_root():
     return {'folder': '/',
             'admin_dbmid': 'dbmid:dummy',
-            'team_folder_id': '1234567890'}
+            'team_folder_id': '1234567890',
+            'team_folder_name': 'team_folder_name'}
 
 
 @pytest.fixture

--- a/tests/providers/nextcloud/test_metadata.py
+++ b/tests/providers/nextcloud/test_metadata.py
@@ -1,6 +1,6 @@
 import pytest
 
-from waterbutler.providers.nextcloud.metadata import NextcloudFileRevisionMetadata
+from waterbutler.providers.nextcloud.metadata import NextcloudFileRevisionMetadata, NextcloudFileMetadata
 
 from tests.providers.nextcloud.fixtures import (
     auth,
@@ -171,3 +171,13 @@ class TestRevisionMetadata:
         revision = NextcloudFileRevisionMetadata.from_metadata(
             file_metadata_object.provider, self.version, file_metadata_object)
         assert revision == revision_metadata_object
+
+
+class TestBaseNextcloudMetadata:
+    def test_folder_exists_in_href_of_path_function(self):
+        data = NextcloudFileMetadata('/folder_exists/href/test.txt', '/folder_exists/', 'provider', None)
+        assert data.path == '/href/test.txt'
+
+    def test_folder_not_exists_in_href_of_path_function(self):
+        data = NextcloudFileMetadata('/href/test.txt', '/folder/', 'provider', None)
+        assert data.path == '/test.txt'

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -182,7 +182,7 @@ class DropboxProvider(provider.BaseProvider):
                     header = {
                         'Dropbox-API-Path-Root': json.dumps({
                             '.tag': 'root',
-                             'root': current_account['root_info']['root_namespace_id']
+                            'root': current_account['root_info']['root_namespace_id']
                         })
                     }
                     data = await self.dropbox_request(

--- a/waterbutler/providers/dropboxbusiness/provider.py
+++ b/waterbutler/providers/dropboxbusiness/provider.py
@@ -11,6 +11,7 @@ class DropboxBusinessProvider(DropboxProvider):
         super().__init__(auth, credentials, settings, **kwargs)
         self.admin_dbmid = self.settings['admin_dbmid']
         self.team_folder_id = self.settings['team_folder_id']
+        self.team_folder_name = self.settings['team_folder_name']
 
     @property
     def default_headers(self) -> dict:

--- a/waterbutler/providers/nextcloud/metadata.py
+++ b/waterbutler/providers/nextcloud/metadata.py
@@ -20,7 +20,14 @@ class BaseNextcloudMetadata(metadata.BaseMetadata):
 
     @property
     def path(self):
-        path = self._href[len(self._folder) - 1:]
+        folder = self._folder
+        href = self._href
+
+        folder_name = folder.strip('/')
+        if folder_name not in href:
+            folder_name_of_href = href.split('/')[1]
+            href = href.replace(folder_name_of_href, folder_name)
+        path = href[len(folder) - 1:]
         return path
 
     @property


### PR DESCRIPTION
## Purpose

Fix bug move file in dropboxbusiness, nextcloud for institution provider

## Changes

In dropboxbusiness provider
    - Add check shares_storage_root when move file
    - Use get_current_account API to get root_namespace_id. Call move_v2 API with root_namespace_id
    - Add loading bar when move/copy file from component to project

In nextcloud for institution
    - Add loading bar when move file from component to project
    - Update function path when move/copy file

## Documentation
    - https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account
    - https://api.dropboxapi.com/2/files/move_v2

## Side Effects

None

## Ticket

2.1.5.親プロジェクトへのファイル移動制限解除