### PR TITLE
[GRDM-40458]  Remove retry logic for response status 404 and 409 on Dropbox provider

### DIFF
--- a/tests/providers/dropbox/fixtures/errors.json
+++ b/tests/providers/dropbox/fixtures/errors.json
@@ -45,6 +45,14 @@
             "id": "id:jki_ZJstdSAAAAAAAAAACQ",
             "rev": "45bb27d11",
             "size": 364
+        },
+
+    "too_many_requests_error": {
+            "error_summary": "too_many_requests/",
+            "error": {
+                "reason": {".tag": "too_many_requests"},
+                "retry_after": 15
+                    }
         }
 
 


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

GRDM-40458

## Purpose

This is a modification of Pull Request https://github.com/RCOSDP/RDM-waterbutler/pull/55.

## Changes

- Remove retry logic for response status 404 and 409 on Dropbox provider.
- In the case of file uploads, retrying the API upload can cause the API not to respond from the provider. Therefore, for file uploads, do not retry when encountering a status 429.

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
