### PR TITLE
[GRDM-44827] Fix bug when upload file larger than a certain size to S3 Compatible Storage for Institutions

### DIFF
--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -381,7 +381,7 @@ class S3CompatProvider(provider.BaseProvider):
             headers = {'x-amz-server-side-encryption': 'AES256'}
         params = {'uploads': ''}
         upload_url = functools.partial(
-            self.bucket.new_key(path.path).generate_url,
+            self.bucket.new_key(path.full_path).generate_url,
             settings.TEMP_URL_SECS,
             'POST',
             query_parameters=params,
@@ -430,7 +430,7 @@ class S3CompatProvider(provider.BaseProvider):
             'uploadId': session_upload_id,
         }
         upload_url = functools.partial(
-            self.bucket.new_key(path.path).generate_url,
+            self.bucket.new_key(path.full_path).generate_url,
             settings.TEMP_URL_SECS,
             'PUT',
             query_parameters=params,
@@ -471,7 +471,7 @@ class S3CompatProvider(provider.BaseProvider):
         headers = {}
         params = {'uploadId': session_upload_id}
         abort_url = functools.partial(
-            self.bucket.new_key(path.path).generate_url,
+            self.bucket.new_key(path.full_path).generate_url,
             settings.TEMP_URL_SECS,
             'DELETE',
             query_parameters=params,
@@ -532,7 +532,7 @@ class S3CompatProvider(provider.BaseProvider):
         headers = {}
         params = {'uploadId': session_upload_id}
         list_url = functools.partial(
-            self.bucket.new_key(path.path).generate_url,
+            self.bucket.new_key(path.full_path).generate_url,
             settings.TEMP_URL_SECS,
             'GET',
             query_parameters=params,
@@ -576,7 +576,7 @@ class S3CompatProvider(provider.BaseProvider):
         }
         params = {'uploadId': session_upload_id}
         complete_url = functools.partial(
-            self.bucket.new_key(path.path).generate_url,
+            self.bucket.new_key(path.full_path).generate_url,
             settings.TEMP_URL_SECS,
             'POST',
             query_parameters=params,


### PR DESCRIPTION
## Ticket

GRDM-44827

## Purpose

Fix bug when uploading file larger than a certain size to S3 Compatible Storage for Institutions.

## Changes

Change path.path to path.full_path in providers/s3compat/provider.py when calling API to Storage provider.

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
