### PR TITLE
[GRDM-49760] WEKOアイテムの解析処理において不可視アイテムに対応

### DIFF
--- a/tests/providers/weko/test_client.py
+++ b/tests/providers/weko/test_client.py
@@ -37,7 +37,62 @@ fake_weko_items = {
             fake_weko_item,
             {
                 'id': 'dummy',
-            }
+            },
+            {
+                'id': 'empty-metadata-1',
+                'metadata': {},
+            },
+            {
+                'id': 'empty-metadata-2',
+                'metadata': {
+                    '_item_metadata': {},
+                },
+            },
+            {
+                'id': 'invalid-metadata-1',
+                'metadata': {
+                    '_item_metadata': {
+                        'title': [],
+                    },
+                },
+            },
+            {
+                'id': 'invalid-metadata-2',
+                'metadata': {
+                    '_item_metadata': {},
+                    'title': [],
+                },
+            },
+            {
+                'id': 'title-on-root-str',
+                'metadata': {
+                    '_item_metadata': {},
+                    'title': 'Sample Item-Text',
+                },
+            },
+            {
+                'id': 'title-on-root-list',
+                'metadata': {
+                    '_item_metadata': {},
+                    'title': ['Sample Item-List'],
+                },
+            },
+            {
+                'id': 'title-on-_item-metadata-str',
+                'metadata': {
+                    '_item_metadata': {
+                        'title': 'Sample Item-Text',
+                    },
+                },
+            },
+            {
+                'id': 'title-on-_item-metadata-list',
+                'metadata': {
+                    '_item_metadata': {
+                        'title': ['Sample Item-List'],
+                    },
+                },
+            },
         ]
     },
 }
@@ -135,9 +190,22 @@ class TestWEKOClient:
         index = await client.get_index_by_id(100)
         items = await index.get_items()
 
-        assert len(items) == 1
+        assert len(items) == 5
         assert items[0].title == 'Sample Item'
+        assert items[0].primary_title == 'Sample Item'
         assert items[0].identifier == 1000
+        assert items[1].title == 'Sample Item-Text'
+        assert items[1].primary_title == 'Sample Item-Text'
+        assert items[1].identifier == 'title-on-root-str'
+        assert items[2].title == 'Sample Item-List'
+        assert items[2].primary_title == 'Sample Item-List'
+        assert items[2].identifier == 'title-on-root-list'
+        assert items[3].title == 'Sample Item-Text'
+        assert items[3].primary_title == 'Sample Item-Text'
+        assert items[3].identifier == 'title-on-_item-metadata-str'
+        assert items[4].title == 'Sample Item-List'
+        assert items[4].primary_title == 'Sample Item-List'
+        assert items[4].identifier == 'title-on-_item-metadata-list'
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/waterbutler/providers/weko/client.py
+++ b/waterbutler/providers/weko/client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Union, List
 from typing_extensions import Self
 from waterbutler.core import exceptions
 
@@ -25,10 +25,14 @@ def _is_valid_index(desc):
 
 
 def _is_valid_item(desc):
-    if 'metadata' in desc:
-        return True
-    logger.warning('Unexpected item description: %s', desc)
-    return False
+    if 'metadata' not in desc:
+        logger.warning('Unexpected item description: %s', desc)
+        return False
+    item = Item(desc)
+    if item.title == '':
+        logger.warning('Item without title: %s', desc)
+        return False
+    return True
 
 
 class Client(object):
@@ -186,18 +190,20 @@ class Item(object):
 
     @property
     def primary_title(self) -> str:
-        v = self._metadata['title']
+        v = self._get_metadata_value('title', '')
         if isinstance(v, str):
             return v
-        return v[0]
+        if isinstance(v, list) and len(v) == 1:
+            return v[0]
+        return ''
 
     @property
     def title(self) -> str:
-        return self._metadata['title']
+        return self.primary_title
 
     @property
     def updated(self):
-        return self._metadata['updated']
+        return self._get_metadata_value('updated')
 
     @property
     def _metadata(self):
@@ -205,6 +211,14 @@ class Item(object):
         if '_item_metadata' in metadata:
             return metadata['_item_metadata']
         return metadata
+
+    def _get_metadata_value(self, key: str, default=None) -> Union[str, List[str], None]:
+        metadata = self.raw['metadata']
+        if '_item_metadata' in metadata and key in metadata['_item_metadata']:
+            return metadata['_item_metadata'][key]
+        if key in metadata:
+            return metadata[key]
+        return default
 
     @property
     def files(self):


### PR DESCRIPTION
## Ticket

GRDM-49760

## Purpose

WEKOアイテムの解析処理において不可視アイテムに対応

## Changes

WEKOから取得したアイテム情報に関して、 `title` 属性が `metadata` または `metadata._item_metadata` になければアイテムとしては無視するように修正。

## Side effects

None

## QA Notes

None

## Deployment Notes

None
