### PR TITLE
[GRDM-50089] Fixing errors when versioning is enabled on S3 compatible storage

### DIFF
--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -171,6 +171,21 @@ def build_folder_params_with_max_key(path):
     return {'prefix': path.path, 'delimiter': '/', 'max-keys': '1000'}
 
 
+def prepare_xml_body(object_dict):
+    payload = '<?xml version="1.0" encoding="UTF-8"?>'
+    payload += '<Delete>'
+    payload += ''.join(
+        '<Object><Key>{}</Key><VersionId>{}</VersionId></Object>'.format(
+            xml.sax.saxutils.escape(key), xml.sax.saxutils.escape(version)
+        )
+        for key, value in object_dict.items()
+        for version in value
+    )
+    payload += '</Delete>'
+    payload = payload.encode('utf-8')
+    return payload
+
+
 class TestRegionDetection:
 
     @pytest.mark.asyncio
@@ -824,25 +839,35 @@ class TestCRUD:
         aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_metadata)
 
         # Mock delete calls for each version ID from version_metadata
-        version_ids = [
+        version_ids = {'my-image.jpg': [
             '3/L4kqtJl40Nr8X8gdRQBpUMLUo',
             'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893',
             'UIORUnfndfhnw89493jJFJ'
-        ]
+        ]}
+        payload_xml = prepare_xml_body(version_ids)
+        md5 = compute_md5(BytesIO(payload_xml))
+        headers = {
+            'Content-Length': str(len(payload_xml)),
+            'Content-MD5': md5[1],
+            'Content-Type': 'text/xml',
+        }
 
-        for version_id in version_ids:
-            delete_url = provider.bucket.new_key(path.path).generate_url(
-                100,
-                'DELETE',
-                query_parameters={'versionId': version_id}
-            )
-            aiohttpretty.register_uri('DELETE', delete_url, status=204)
+        query_params = {'delete': ''}
+        # We depend on a customized version of boto that can make query parameters part of
+        # the signature.
+        delete_url = provider.bucket.generate_url(
+            100,
+            'POST',
+            query_parameters=query_params,
+            headers=headers
+        )
+        aiohttpretty.register_uri('POST', delete_url, params=query_params, status=200)
 
         await provider.delete(path)
 
-        # Verify delete calls were made for each version
-        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
-        assert len(delete_calls) == 3
+        # Verify delete called
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'POST']
+        assert len(delete_calls) == 1
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -861,36 +886,38 @@ class TestCRUD:
         )
 
         # Mock delete calls for each version ID from version_metadata
-        versions = [
-            {
-                'id': '3/L4kqtJl40Nr8X8gdRQBpUMLUo',
-                'path': WaterButlerPath('/my-image.jpg')
-            },
-            {
-                'id': 'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893',
-                'path': WaterButlerPath('/my-image.jpg')
-            },
-            {
-                'id': 'UIORUnfndfhnw89493jJFJ',
-                'path': WaterButlerPath('/my-image.jpg')
-            }
-        ]
+        version_ids = {'my-image.jpg': [
+            '3/L4kqtJl40Nr8X8gdRQBpUMLUo',
+            'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893',
+            'UIORUnfndfhnw89493jJFJ'
+        ]}
 
-        for version in versions:
-            delete_url = provider.bucket.new_key(version['path']).generate_url(
-                100,
-                'DELETE',
-                query_parameters={'versionId': version['id']}
-            )
-            aiohttpretty.register_uri('DELETE', delete_url, status=204)
+        payload_xml = prepare_xml_body(version_ids)
+        md5 = compute_md5(BytesIO(payload_xml))
+        headers = {
+            'Content-Length': str(len(payload_xml)),
+            'Content-MD5': md5[1],
+            'Content-Type': 'text/xml',
+        }
+
+        query_params = {'delete': ''}
+        # We depend on a customized version of boto that can make query parameters part of
+        # the signature.
+        delete_url = provider.bucket.generate_url(
+            100,
+            'POST',
+            query_parameters=query_params,
+            headers=headers
+        )
+        aiohttpretty.register_uri('POST', delete_url, params=query_params, status=200)
 
         with pytest.raises(exceptions.DeleteError):
             await provider.delete(path)
 
         await provider.delete(path, confirm_delete=1)
 
-        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
-        assert len(delete_calls) == 3
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'POST']
+        assert len(delete_calls) == 1
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -918,16 +945,26 @@ class TestCRUD:
             </ListVersionsResult>'''
 
         aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
+        version_ids = {'folder-to-delete/file1.txt': ['111', '222'],
+                       'folder-to-delete/file2.txt': ['333']}
+        payload_xml = prepare_xml_body(version_ids)
+        md5 = compute_md5(BytesIO(payload_xml))
+        headers = {
+            'Content-Length': str(len(payload_xml)),
+            'Content-MD5': md5[1],
+            'Content-Type': 'text/xml',
+        }
+
+        query_params = {'delete': ''}
 
         # Mock delete requests for each version
-        for version_id in ['111', '222', '333']:
-            for file_path in ['folder-to-delete/file1.txt', 'folder-to-delete/file2.txt']:
-                delete_url = provider.bucket.new_key(file_path).generate_url(
-                    100,
-                    'DELETE',
-                    query_parameters={'versionId': version_id}
-                )
-                aiohttpretty.register_uri('DELETE', delete_url, status=204)
+        delete_url = provider.bucket.generate_url(
+            100,
+            'POST',
+            query_parameters=query_params,
+            headers=headers
+        )
+        aiohttpretty.register_uri('POST', delete_url, params=query_params, status=200)
 
         await provider._delete_folder(path)
 
@@ -935,8 +972,8 @@ class TestCRUD:
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
 
         # Verify delete calls were made for each version
-        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
-        assert len(delete_calls) == 3
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'POST']
+        assert len(delete_calls) == 1
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -984,12 +1021,26 @@ class TestCRUD:
             ('111', 'large-folder/file1.txt'),
             ('222', 'large-folder/file2.txt')
         ]:
-            delete_url = provider.bucket.new_key(file_path).generate_url(
+            version_ids = {file_path: [version_id]
+                           }
+            payload_xml = prepare_xml_body(version_ids)
+            md5 = compute_md5(BytesIO(payload_xml))
+            headers = {
+                'Content-Length': str(len(payload_xml)),
+                'Content-MD5': md5[1],
+                'Content-Type': 'text/xml',
+            }
+
+            query_params = {'delete': ''}
+
+            # Mock delete requests for each version
+            delete_url = provider.bucket.generate_url(
                 100,
-                'DELETE',
-                query_parameters={'versionId': version_id}
+                'POST',
+                query_parameters=query_params,
+                headers=headers
             )
-            aiohttpretty.register_uri('DELETE', delete_url, status=204)
+            aiohttpretty.register_uri('POST', delete_url, params=query_params, status=200)
 
         await provider._delete_folder(path)
 
@@ -998,7 +1049,7 @@ class TestCRUD:
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params2)
 
         # Verify delete calls were made for each version
-        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'POST']
         assert len(delete_calls) == 2
 
     @pytest.mark.asyncio
@@ -1043,19 +1094,32 @@ class TestCRUD:
         aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
 
         # Mock failed delete request
-        delete_url = provider.bucket.new_key('error-folder/file1.txt').generate_url(
+        version_ids = {'error-folder/file1.txt': ['111']}
+        payload_xml = prepare_xml_body(version_ids)
+        md5 = compute_md5(BytesIO(payload_xml))
+        headers = {
+            'Content-Length': str(len(payload_xml)),
+            'Content-MD5': md5[1],
+            'Content-Type': 'text/xml',
+        }
+
+        query_params = {'delete': ''}
+
+        # Mock delete requests for each version
+        delete_url = provider.bucket.generate_url(
             100,
-            'DELETE',
-            query_parameters={'versionId': '111'}
+            'POST',
+            query_parameters=query_params,
+            headers=headers
         )
-        aiohttpretty.register_uri('DELETE', delete_url, status=403)
+        aiohttpretty.register_uri('POST', delete_url, params=query_params, status=403)
 
         with pytest.raises(exceptions.DeleteError):
             await provider._delete_folder(path)
 
         # Verify both requests were made
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
-        assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
+        assert aiohttpretty.has_call(method='POST', uri=delete_url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -815,190 +815,247 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_delete(self, provider, mock_time):
-        path = WaterButlerPath('/some-file')
-        url = provider.bucket.new_key(path.path).generate_url(100, 'DELETE')
-        aiohttpretty.register_uri('DELETE', url, status=200)
+    async def test_delete(self, provider, version_metadata, mock_time):
+        path = WaterButlerPath('/my-image.jpg')
+
+        # Mock the versions list response
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {'prefix': path.path, 'delimiter': '/'}
+        aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_metadata)
+
+        # Mock delete calls for each version ID from version_metadata
+        version_ids = [
+            '3/L4kqtJl40Nr8X8gdRQBpUMLUo',
+            'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893',
+            'UIORUnfndfhnw89493jJFJ'
+        ]
+
+        for version_id in version_ids:
+            delete_url = provider.bucket.new_key(path.path).generate_url(
+                100,
+                'DELETE',
+                query_parameters={'versionId': version_id}
+            )
+            aiohttpretty.register_uri('DELETE', delete_url, status=204)
 
         await provider.delete(path)
 
-        assert aiohttpretty.has_call(method='DELETE', uri=url)
+        # Verify delete calls were made for each version
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        assert len(delete_calls) == 3
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_delete_comfirm_delete(self, provider, folder_and_contents, mock_time):
+    async def test_delete_confirm_delete(self, provider, version_metadata, mock_time):
         path = WaterButlerPath('/')
 
-        query_url = provider.bucket.generate_url(100, 'GET')
+        # Mock request GET versions
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {'prefix': '', 'versions': ''}
         aiohttpretty.register_uri(
             'GET',
-            query_url,
-            params={'prefix': ''},
-            body=folder_and_contents,
-            status=200,
+            versions_url,
+            params=params,
+            body=version_metadata,
+            status=200
         )
 
-        (payload, headers) = bulk_delete_body(
-            ['thisfolder/', 'thisfolder/item1', 'thisfolder/item2']
-        )
-        delete_url = provider.bucket.generate_url(
-            100,
-            'POST',
-            query_parameters={'delete': ''},
-            headers=headers,
-        )
-        aiohttpretty.register_uri('POST', delete_url, status=204)
+        # Mock delete calls for each version ID from version_metadata
+        versions = [
+            {
+                'id': '3/L4kqtJl40Nr8X8gdRQBpUMLUo',
+                'path': WaterButlerPath('/my-image.jpg')
+            },
+            {
+                'id': 'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893',
+                'path': WaterButlerPath('/my-image.jpg')
+            },
+            {
+                'id': 'UIORUnfndfhnw89493jJFJ',
+                'path': WaterButlerPath('/my-image.jpg')
+            }
+        ]
+
+        for version in versions:
+            delete_url = provider.bucket.new_key(version['path']).generate_url(
+                100,
+                'DELETE',
+                query_parameters={'versionId': version['id']}
+            )
+            aiohttpretty.register_uri('DELETE', delete_url, status=204)
 
         with pytest.raises(exceptions.DeleteError):
             await provider.delete(path)
 
         await provider.delete(path, confirm_delete=1)
 
-        assert aiohttpretty.has_call(method='POST', uri=delete_url)
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        assert len(delete_calls) == 3
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_folder_delete(self, provider, folder_and_contents, mock_time):
-        path = WaterButlerPath('/some-folder/')
+    async def test_delete_folder_with_versions(self, provider, mock_time):
+        path = WaterButlerPath('/folder-to-delete/')
 
-        params = {'prefix': 'some-folder/'}
-        query_url = provider.bucket.generate_url(100, 'GET')
-        aiohttpretty.register_uri(
-            'GET',
-            query_url,
-            params=params,
-            body=folder_and_contents,
-            status=200,
-        )
+        # Mock list versions response
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {'prefix': path.path, 'versions': ''}
 
-        query_params = {'delete': ''}
-        (payload, headers) = bulk_delete_body(
-            ['thisfolder/', 'thisfolder/item1', 'thisfolder/item2']
-        )
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <Version>
+                    <Key>folder-to-delete/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+                <Version>
+                    <Key>folder-to-delete/file1.txt</Key>
+                    <VersionId>222</VersionId>
+                </Version>
+                <DeleteMarker>
+                    <Key>folder-to-delete/file2.txt</Key>
+                    <VersionId>333</VersionId>
+                </DeleteMarker>
+            </ListVersionsResult>'''
 
-        delete_url = provider.bucket.generate_url(
-            100,
-            'POST',
-            query_parameters=query_params,
-            headers=headers,
-        )
-        aiohttpretty.register_uri('POST', delete_url, status=204)
+        aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
 
-        await provider.delete(path)
+        # Mock delete requests for each version
+        for version_id in ['111', '222', '333']:
+            for file_path in ['folder-to-delete/file1.txt', 'folder-to-delete/file2.txt']:
+                delete_url = provider.bucket.new_key(file_path).generate_url(
+                    100,
+                    'DELETE',
+                    query_parameters={'versionId': version_id}
+                )
+                aiohttpretty.register_uri('DELETE', delete_url, status=204)
 
-        assert aiohttpretty.has_call(method='GET', uri=query_url, params=params)
-        assert aiohttpretty.has_call(method='POST', uri=delete_url)
+        await provider._delete_folder(path)
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_single_item_folder_delete(self,
-                                             provider,
-                                             folder_single_item_metadata,
-                                             mock_time):
-        path = WaterButlerPath('/single-thing-folder/')
+        # Verify list versions request was made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
 
-        params = {'prefix': 'single-thing-folder/'}
-        query_url = provider.bucket.generate_url(100, 'GET')
-        aiohttpretty.register_uri(
-            'GET',
-            query_url,
-            params=params,
-            body=folder_single_item_metadata,
-            status=200,
-        )
-
-        (payload, headers) = bulk_delete_body(
-            ['my-image.jpg']
-        )
-        delete_url = provider.bucket.generate_url(
-            100,
-            'POST',
-            query_parameters={'delete': ''},
-            headers=headers,
-        )
-        aiohttpretty.register_uri('POST', delete_url, status=204)
-
-
-        await provider.delete(path)
-        assert aiohttpretty.has_call(method='GET', uri=query_url, params=params)
-        aiohttpretty.register_uri('POST', delete_url, status=204)
+        # Verify delete calls were made for each version
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        assert len(delete_calls) == 3
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_empty_folder_delete(self, provider, folder_empty_metadata, mock_time):
-        path = WaterButlerPath('/empty-folder/')
+    async def test_delete_folder_truncated_response(self, provider, mock_time):
+        path = WaterButlerPath('/large-folder/')
 
-        params = {'prefix': 'empty-folder/'}
-        query_url = provider.bucket.generate_url(100, 'GET')
-        aiohttpretty.register_uri(
-            'GET',
-            query_url,
-            params=params,
-            body=folder_empty_metadata,
-            status=200,
-        )
+        # Mock first list versions response (truncated)
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params1 = {'prefix': path.path, 'versions': ''}
+
+        list_versions_body1 = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>true</IsTruncated>
+                <NextKeyMarker>large-folder/file2.txt</NextKeyMarker>
+                <NextVersionIdMarker>222</NextVersionIdMarker>
+                <Version>
+                    <Key>large-folder/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params1, body=list_versions_body1, status=200)
+
+        # Mock second list versions response
+        params2 = {
+            'prefix': path.path,
+            'versions': '',
+            'key-marker': 'large-folder/file2.txt',
+            'version-id-marker': '222'
+        }
+
+        list_versions_body2 = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>false</IsTruncated>
+                <Version>
+                    <Key>large-folder/file2.txt</Key>
+                    <VersionId>222</VersionId>
+                </Version>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params2, body=list_versions_body2, status=200)
+
+        # Mock delete requests
+        for version_id, file_path in [
+            ('111', 'large-folder/file1.txt'),
+            ('222', 'large-folder/file2.txt')
+        ]:
+            delete_url = provider.bucket.new_key(file_path).generate_url(
+                100,
+                'DELETE',
+                query_parameters={'versionId': version_id}
+            )
+            aiohttpretty.register_uri('DELETE', delete_url, status=204)
+
+        await provider._delete_folder(path)
+
+        # Verify both list versions requests were made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params1)
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params2)
+
+        # Verify delete calls were made for each version
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        assert len(delete_calls) == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_folder_not_found(self, provider, mock_time):
+        path = WaterButlerPath('/not-found-folder/')
+
+        # Mock empty list versions response
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {'prefix': path.path, 'versions': ''}
+
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>false</IsTruncated>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
 
         with pytest.raises(exceptions.NotFoundError):
-            await provider.delete(path)
+            await provider._delete_folder(path)
 
-        assert aiohttpretty.has_call(method='GET', uri=query_url, params=params)
+        # Verify list versions request was made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_large_folder_delete(self, provider, mock_time):
-        path = WaterButlerPath('/some-folder/')
+    async def test_delete_folder_delete_error(self, provider, mock_time):
+        path = WaterButlerPath('/error-folder/')
 
-        query_url = provider.bucket.generate_url(100, 'GET')
+        # Mock list versions response
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {'prefix': path.path, 'versions': ''}
 
-        keys_one = [str(x) for x in range(2500, 3500)]
-        response_one = list_objects_response(keys_one, truncated=True)
-        params_one = {'prefix': 'some-folder/'}
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <Version>
+                    <Key>error-folder/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+            </ListVersionsResult>'''
 
-        keys_two = [str(x) for x in range(3500, 3601)]
-        response_two = list_objects_response(keys_two)
-        params_two = {'prefix': 'some-folder/', 'marker': '3499'}
+        aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
 
-        aiohttpretty.register_uri(
-            'GET',
-            query_url,
-            params=params_one,
-            body=response_one,
-            status=200,
-        )
-        aiohttpretty.register_uri(
-            'GET',
-            query_url,
-            params=params_two,
-            body=response_two,
-            status=200,
-        )
-
-        query_params = {'delete': None}
-
-        (payload_one, headers_one) = bulk_delete_body(keys_one)
-        delete_url_one = provider.bucket.generate_url(
+        # Mock failed delete request
+        delete_url = provider.bucket.new_key('error-folder/file1.txt').generate_url(
             100,
-            'POST',
-            query_parameters=query_params,
-            headers=headers_one,
+            'DELETE',
+            query_parameters={'versionId': '111'}
         )
-        aiohttpretty.register_uri('POST', delete_url_one, status=204)
+        aiohttpretty.register_uri('DELETE', delete_url, status=403)
 
-        (payload_two, headers_two) = bulk_delete_body(keys_two)
-        delete_url_two = provider.bucket.generate_url(
-            100,
-            'POST',
-            query_parameters=query_params,
-            headers=headers_two,
-        )
-        aiohttpretty.register_uri('POST', delete_url_two, status=204)
+        with pytest.raises(exceptions.DeleteError):
+            await provider._delete_folder(path)
 
-        await provider.delete(path)
-
-        assert aiohttpretty.has_call(method='GET', uri=query_url, params=params_one)
-        assert aiohttpretty.has_call(method='GET', uri=query_url, params=params_two)
-        assert aiohttpretty.has_call(method='POST', uri=delete_url_one)
-        assert aiohttpretty.has_call(method='POST', uri=delete_url_two)
+        # Verify both requests were made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
+        assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -761,10 +761,14 @@ class TestCRUD:
         head_url = generate_url(100, 'HEAD')
         aiohttpretty.register_uri('HEAD', head_url, headers=file_header_metadata)
 
-        response_headers = {'response-content-disposition': 'attachment'}
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         get_url = generate_url(100, response_headers=response_headers)
-        aiohttpretty.register_uri('GET', get_url[:get_url.index('?')],
-                                  body=b'delicious', headers=file_header_metadata, auto_length=True)
+
+        aiohttpretty.register_uri('GET', get_url,
+                              body=b'delicious',
+                              headers=file_header_metadata,
+                              auto_length=True)
 
         result = await provider.download(path)
         content = await result.read()
@@ -781,9 +785,10 @@ class TestCRUD:
         head_url = generate_url(100, 'HEAD')
         aiohttpretty.register_uri('HEAD', head_url, headers=file_header_metadata)
 
-        response_headers = {'response-content-disposition': 'attachment;'}
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         get_url = generate_url(100, response_headers=response_headers)
-        aiohttpretty.register_uri('GET', get_url[:get_url.index('?')],
+        aiohttpretty.register_uri('GET', get_url,
                                   body=b'de', auto_length=True, status=206)
 
         result = await provider.download(path, range=(0, 1))
@@ -792,7 +797,7 @@ class TestCRUD:
         content_size = result._size
         assert content == b'de'
         assert content_size == 2
-        assert aiohttpretty.has_call(method='GET', uri=get_url[:get_url.index('?')])
+        assert aiohttpretty.has_call(method='GET', uri=get_url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -807,9 +812,10 @@ class TestCRUD:
         get_url = generate_url(
             100,
             query_parameters=versionid_parameter,
-            response_headers={'response-content-disposition': 'attachment'},
+            response_headers = {'response-content-disposition':
+                                'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         )
-        aiohttpretty.register_uri('GET', get_url[:get_url.index('?')],
+        aiohttpretty.register_uri('GET', get_url,
                                   body=b'delicious', auto_length=True)
 
         result = await provider.download(path, version='someversion')
@@ -832,11 +838,12 @@ class TestCRUD:
         aiohttpretty.register_uri('HEAD', head_url, headers={'Content-Length': '9'})
 
         response_headers = {
-            'response-content-disposition':
-            'attachment; filename="{}"; filename*=UTF-8''{}'.format(expected_name, expected_name)
+            'response-content-disposition': ('attachment; filename="{}"; '
+                                             'filename*=UTF-8\'\'{}').format(expected_name,
+                                                                             expected_name)
         }
         get_url = generate_url(100, response_headers=response_headers)
-        aiohttpretty.register_uri('GET', get_url[:get_url.index('?')],
+        aiohttpretty.register_uri('GET', get_url,
                                   body=b'delicious', auto_length=True)
 
         result = await provider.download(path, display_name=display_name_arg)
@@ -853,9 +860,10 @@ class TestCRUD:
         head_url = generate_url(100, 'HEAD')
         aiohttpretty.register_uri('HEAD', head_url, status=404)
 
-        response_headers = {'response-content-disposition': 'attachment'}
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         url = generate_url(100, response_headers=response_headers)
-        aiohttpretty.register_uri('GET', url[:url.index('?')], status=404)
+        aiohttpretty.register_uri('GET', url, status=404)
 
         with pytest.raises(exceptions.DownloadError):
             await provider.download(path)
@@ -874,9 +882,10 @@ class TestCRUD:
         no_content_length_metadata = file_header_metadata.copy()
         del no_content_length_metadata['Content-Length']
 
-        response_headers = {'response-content-disposition': 'attachment'}
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         get_url = generate_url(100, response_headers=response_headers)
-        aiohttpretty.register_uri('GET', get_url[:get_url.index('?')],
+        aiohttpretty.register_uri('GET', get_url,
                                   body=b'delicious', headers=no_content_length_metadata)
 
         result = await provider.download(path)
@@ -897,9 +906,10 @@ class TestCRUD:
         head_url = generate_url(100, 'HEAD')
         aiohttpretty.register_uri('HEAD', head_url, headers=head_header_metadata)
 
-        response_headers = {'response-content-disposition': 'attachment'}
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
         get_url = generate_url(100, response_headers=response_headers)
-        aiohttpretty.register_uri('GET', get_url[:get_url.index('?')],
+        aiohttpretty.register_uri('GET', get_url,
                                   body=b'delicious', headers=file_header_metadata, auto_length=True)
 
         result = await provider.download(path)
@@ -908,7 +918,7 @@ class TestCRUD:
         assert content == b'delicious'
         assert result._size == 9
         assert aiohttpretty.has_call(method='HEAD', uri=head_url)
-        assert aiohttpretty.has_call(method='GET', uri=get_url[:get_url.index('?')])
+        assert aiohttpretty.has_call(method='GET', uri=get_url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -1647,7 +1657,7 @@ class TestCRUD:
             100,
             'GET',
             query_parameters={'uploadId': upload_id}
-        )    
+        )
         aiohttpretty.register_uri('GET', list_url_full_path, body=list_parts_resp_empty, status=200)
         aiohttpretty.register_uri('GET', list_url_path, body=list_parts_resp_empty, status=200)
 
@@ -1662,39 +1672,89 @@ class TestCRUD:
     @pytest.mark.aiohttpretty
     async def test_delete(self, provider, mock_time):
         path = WaterButlerPath('/some-file', prepend=provider.prefix)
-        url = provider.bucket.new_key(path.full_path).generate_url(100, 'DELETE')
-        aiohttpretty.register_uri('DELETE', url, status=200)
+
+        # Mock the versions list response
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {
+            'prefix': path.path.lstrip('/'),  # Remove leading slash
+            'delimiter': '/',
+            'versions': ''  # Add versions parameter
+        }
+        version_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
+                <Name>bucket</Name>
+                <Prefix>some-file</Prefix>
+                <KeyMarker/>
+                <VersionIdMarker/>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                <Version>
+                    <Key>some-file</Key>
+                    <VersionId>null</VersionId>
+                    <IsLatest>true</IsLatest>
+                    <LastModified>2023-01-01T00:00:00.000Z</LastModified>
+                    <ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
+                    <Size>0</Size>
+                    <Owner>
+                        <ID>minio</ID>
+                        <DisplayName>minio</DisplayName>
+                    </Owner>
+                    <StorageClass>STANDARD</StorageClass>
+                </Version>
+            </ListVersionsResult>'''
+        aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_body)
+
+        # Mock the delete response for version
+        delete_version_url = provider.bucket.new_key(path.full_path).generate_url(
+            100,
+            'DELETE',
+            query_parameters={'versionId': 'null'}
+        )
+        aiohttpretty.register_uri('DELETE', delete_version_url, status=200)
 
         await provider.delete(path)
 
-        assert aiohttpretty.has_call(method='DELETE', uri=url)
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
+        assert aiohttpretty.has_call(method='DELETE', uri=delete_version_url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_delete_confirm_delete(self, provider, folder_and_contents, mock_time):
-        path = WaterButlerPath('/', prepend=provider.prefix)
+    async def test_delete_confirm_delete(self, provider, version_metadata, mock_time):
+        path = WaterButlerPath('/')
 
-        params = {'prefix': path.full_path.lstrip('/')}
-        query_url = provider.bucket.generate_url(100, 'GET')
+        # Mock request GET versions
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {'prefix': '', 'versions': ''}
         aiohttpretty.register_uri(
             'GET',
-            query_url,
+            versions_url,
             params=params,
-            body=folder_and_contents,
-            status=200,
+            body=version_metadata,
+            status=200
         )
 
-        target_items = ['thisfolder/', 'thisfolder/item1', 'thisfolder/item2']
-        delete_urls = []
-        prefix = provider.prefix
-        if prefix is None:
-            prefix = ''
-        for i in target_items:
-            delete_url = provider.bucket.new_key(prefix + i).generate_url(
+        # Mock delete calls for each version ID from version_metadata
+        versions = [
+            {
+                'id': '3/L4kqtJl40Nr8X8gdRQBpUMLUo',
+                'path': WaterButlerPath('/my-image.jpg')
+            },
+            {
+                'id': 'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893',
+                'path': WaterButlerPath('/my-image.jpg')
+            },
+            {
+                'id': 'UIORUnfndfhnw89493jJFJ',
+                'path': WaterButlerPath('/my-image.jpg')
+            }
+        ]
+
+        for version in versions:
+            delete_url = provider.bucket.new_key(version['path']).generate_url(
                 100,
                 'DELETE',
+                query_parameters={'versionId': version['id']}
             )
-            delete_urls.append(delete_url)
             aiohttpretty.register_uri('DELETE', delete_url, status=204)
 
         with pytest.raises(exceptions.DeleteError):
@@ -1702,73 +1762,188 @@ class TestCRUD:
 
         await provider.delete(path, confirm_delete=1)
 
-        assert aiohttpretty.has_call(method='GET', uri=query_url, params=params)
-        for delete_url in delete_urls:
-            assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        assert len(delete_calls) == 3
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_folder_delete(self, provider, folder_and_contents, mock_time):
-        path = WaterButlerPath('/some-folder/', prepend=provider.prefix)
+    async def test_delete_folder_with_versions(self, provider, mock_time):
+        path = WaterButlerPath('/folder-to-delete/')
 
-        params = {'prefix': path.full_path.lstrip('/')}
-        query_url = provider.bucket.generate_url(100, 'GET')
-        aiohttpretty.register_uri(
-            'GET',
-            query_url,
-            params=params,
-            body=folder_and_contents,
-            status=200,
-        )
+        # Mock list versions response
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {'prefix': path.path, 'versions': ''}
 
-        target_items = ['thisfolder/', 'thisfolder/item1', 'thisfolder/item2']
-        delete_urls = []
-        prefix = provider.prefix
-        if prefix is None:
-            prefix = ''
-        for i in target_items:
-            delete_url = provider.bucket.new_key(prefix + i).generate_url(
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <Version>
+                    <Key>folder-to-delete/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+                <Version>
+                    <Key>folder-to-delete/file1.txt</Key>
+                    <VersionId>222</VersionId>
+                </Version>
+                <DeleteMarker>
+                    <Key>folder-to-delete/file2.txt</Key>
+                    <VersionId>333</VersionId>
+                </DeleteMarker>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
+
+        # Mock delete requests for each version
+        for version_id in ['111', '222', '333']:
+            for file_path in ['folder-to-delete/file1.txt', 'folder-to-delete/file2.txt']:
+                delete_url = provider.bucket.new_key(file_path).generate_url(
+                    100,
+                    'DELETE',
+                    query_parameters={'versionId': version_id}
+                )
+                aiohttpretty.register_uri('DELETE', delete_url, status=204)
+
+        await provider._delete_folder(path)
+
+        # Verify list versions request was made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
+
+        # Verify delete calls were made for each version
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        assert len(delete_calls) == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_folder_truncated_response(self, provider, mock_time):
+        path = WaterButlerPath('/large-folder/')
+
+        # Mock first list versions response (truncated)
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params1 = {'prefix': path.path, 'versions': ''}
+
+        list_versions_body1 = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>true</IsTruncated>
+                <NextKeyMarker>large-folder/file2.txt</NextKeyMarker>
+                <NextVersionIdMarker>222</NextVersionIdMarker>
+                <Version>
+                    <Key>large-folder/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params1, body=list_versions_body1, status=200)
+
+        # Mock second list versions response
+        params2 = {
+            'prefix': path.path,
+            'versions': '',
+            'key-marker': 'large-folder/file2.txt',
+            'version-id-marker': '222'
+        }
+
+        list_versions_body2 = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>false</IsTruncated>
+                <Version>
+                    <Key>large-folder/file2.txt</Key>
+                    <VersionId>222</VersionId>
+                </Version>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params2, body=list_versions_body2, status=200)
+
+        # Mock delete requests
+        for version_id, file_path in [
+            ('111', 'large-folder/file1.txt'),
+            ('222', 'large-folder/file2.txt')
+        ]:
+            delete_url = provider.bucket.new_key(file_path).generate_url(
                 100,
                 'DELETE',
+                query_parameters={'versionId': version_id}
             )
-            delete_urls.append(delete_url)
             aiohttpretty.register_uri('DELETE', delete_url, status=204)
 
-        await provider.delete(path)
+        await provider._delete_folder(path)
 
-        assert aiohttpretty.has_call(method='GET', uri=query_url, params=params)
-        for delete_url in delete_urls:
-            assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
+        # Verify both list versions requests were made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params1)
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params2)
+
+        # Verify delete calls were made for each version
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        assert len(delete_calls) == 2
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_single_item_folder_delete(self, provider, folder_single_item_metadata, mock_time):
-        path = WaterButlerPath('/single-thing-folder/', prepend=provider.prefix)
+    async def test_delete_folder_not_found(self, provider, mock_time):
+        path = WaterButlerPath('/not-found-folder/')
+        prefix = path.path.lstrip('/')  # 'not-found-folder/'
 
-        params = {'prefix': path.full_path.lstrip('/')}
-        query_url = provider.bucket.generate_url(100, 'GET')
-        aiohttpretty.register_uri(
-            'GET',
-            query_url,
-            params=params,
-            body=folder_single_item_metadata,
-            status=200,
-        )
+        # Mock list versions response
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        versions_params = {'prefix': prefix, 'versions': ''}
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>false</IsTruncated>
+            </ListVersionsResult>'''
+        aiohttpretty.register_uri('GET', versions_url, params=versions_params,
+                                body=list_versions_body, status=200)
 
-        prefix = 'my-image.jpg'
-        delete_url = provider.bucket.new_key(prefix).generate_url(
+        # Mock folder exists check
+        exists_url = provider.bucket.generate_url(100, 'GET')
+        exists_params = {'prefix': prefix.rstrip('/'), 'delimiter': '/'}
+        exists_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>bucket</Name>
+                <Prefix>not-found-folder</Prefix>
+                <Marker/>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+            </ListBucketResult>'''
+        aiohttpretty.register_uri('GET', exists_url, params=exists_params,
+                                body=exists_body, status=200)
+
+        with pytest.raises(exceptions.NotFoundError):
+            await provider._delete_folder(path)
+
+        # Verify both requests were made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=versions_params)
+        assert aiohttpretty.has_call(method='GET', uri=exists_url, params=exists_params)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_folder_delete_error(self, provider, mock_time):
+        path = WaterButlerPath('/error-folder/')
+
+        # Mock list versions response
+        versions_url = provider.bucket.generate_url(100, 'GET', query_parameters={'versions': ''})
+        params = {'prefix': path.path, 'versions': ''}
+
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <Version>
+                    <Key>error-folder/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
+
+        # Mock failed delete request
+        delete_url = provider.bucket.new_key('error-folder/file1.txt').generate_url(
             100,
             'DELETE',
+            query_parameters={'versionId': '111'}
         )
-        aiohttpretty.register_uri('DELETE', delete_url, status=204)
+        aiohttpretty.register_uri('DELETE', delete_url, status=403)
 
-        await provider.delete(path)
+        with pytest.raises(exceptions.DeleteError):
+            await provider._delete_folder(path)
 
-        assert aiohttpretty.has_call(method='GET', uri=query_url, params=params)
+        # Verify both requests were made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
         assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
-        (payload, headers) = bulk_delete_body(
-            ['my-image.jpg']
-        )
 
 
 class TestMetadata:

--- a/tests/providers/s3compat/test_provider.py
+++ b/tests/providers/s3compat/test_provider.py
@@ -625,6 +625,21 @@ def list_upload_chunks_body(parts_metadata):
     return payload, headers
 
 
+def prepare_xml_body(object_dict):
+    payload = '<?xml version="1.0" encoding="UTF-8"?>'
+    payload += '<Delete>'
+    payload += ''.join(
+        '<Object><Key>{}</Key><VersionId>{}</VersionId></Object>'.format(
+            xml.sax.saxutils.escape(key), xml.sax.saxutils.escape(version)
+        )
+        for key, value in object_dict.items()
+        for version in value
+    )
+    payload += '</Delete>'
+    payload = payload.encode('utf-8')
+    return payload
+
+
 class TestProviderConstruction:
 
     def test_https(self, auth, credentials, settings):
@@ -1705,17 +1720,29 @@ class TestCRUD:
         aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_body)
 
         # Mock the delete response for version
-        delete_version_url = provider.bucket.new_key(path.full_path).generate_url(
-            100,
-            'DELETE',
-            query_parameters={'versionId': 'null'}
-        )
-        aiohttpretty.register_uri('DELETE', delete_version_url, status=200)
+        version_ids = {'some-file': ['null']}
+        payload_xml = prepare_xml_body(version_ids)
+        md5 = compute_md5(BytesIO(payload_xml))
+        headers = {
+            'Content-Length': str(len(payload_xml)),
+            'Content-MD5': md5[1],
+            'Content-Type': 'text/xml',
+        }
 
+        query_params = {'delete': ''}
+        # We depend on a customized version of boto that can make query parameters part of
+        # the signature.
+        delete_version_url = provider.bucket.generate_url(
+            100,
+            'POST',
+            query_parameters=query_params,
+            headers=headers
+        )
+        aiohttpretty.register_uri('POST', delete_version_url, params=query_params, status=200)
         await provider.delete(path)
 
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
-        assert aiohttpretty.has_call(method='DELETE', uri=delete_version_url)
+        assert aiohttpretty.has_call(method='POST', uri=delete_version_url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -1734,36 +1761,36 @@ class TestCRUD:
         )
 
         # Mock delete calls for each version ID from version_metadata
-        versions = [
-            {
-                'id': '3/L4kqtJl40Nr8X8gdRQBpUMLUo',
-                'path': WaterButlerPath('/my-image.jpg')
-            },
-            {
-                'id': 'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893',
-                'path': WaterButlerPath('/my-image.jpg')
-            },
-            {
-                'id': 'UIORUnfndfhnw89493jJFJ',
-                'path': WaterButlerPath('/my-image.jpg')
-            }
-        ]
+        version_ids = {'my-image.jpg': [
+            '3/L4kqtJl40Nr8X8gdRQBpUMLUo',
+            'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893',
+            'UIORUnfndfhnw89493jJFJ'
+        ]}
+        payload_xml = prepare_xml_body(version_ids)
+        md5 = compute_md5(BytesIO(payload_xml))
+        headers = {
+            'Content-Length': str(len(payload_xml)),
+            'Content-MD5': md5[1],
+            'Content-Type': 'text/xml',
+        }
 
-        for version in versions:
-            delete_url = provider.bucket.new_key(version['path']).generate_url(
-                100,
-                'DELETE',
-                query_parameters={'versionId': version['id']}
-            )
-            aiohttpretty.register_uri('DELETE', delete_url, status=204)
-
+        query_params = {'delete': ''}
+        # We depend on a customized version of boto that can make query parameters part of
+        # the signature.
+        delete_url = provider.bucket.generate_url(
+            100,
+            'POST',
+            query_parameters=query_params,
+            headers=headers
+        )
+        aiohttpretty.register_uri('POST', delete_url, params=query_params, status=200)
         with pytest.raises(exceptions.DeleteError):
             await provider.delete(path)
 
         await provider.delete(path, confirm_delete=1)
 
-        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
-        assert len(delete_calls) == 3
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'POST']
+        assert len(delete_calls) == 1
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -1793,23 +1820,34 @@ class TestCRUD:
         aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
 
         # Mock delete requests for each version
-        for version_id in ['111', '222', '333']:
-            for file_path in ['folder-to-delete/file1.txt', 'folder-to-delete/file2.txt']:
-                delete_url = provider.bucket.new_key(file_path).generate_url(
-                    100,
-                    'DELETE',
-                    query_parameters={'versionId': version_id}
-                )
-                aiohttpretty.register_uri('DELETE', delete_url, status=204)
+        version_ids = {'folder-to-delete/file1.txt': ['111', '222'],
+                       'folder-to-delete/file2.txt': ['333']}
+        payload_xml = prepare_xml_body(version_ids)
+        md5 = compute_md5(BytesIO(payload_xml))
+        headers = {
+            'Content-Length': str(len(payload_xml)),
+            'Content-MD5': md5[1],
+            'Content-Type': 'text/xml',
+        }
 
+        query_params = {'delete': ''}
+
+        # Mock delete requests for each version
+        delete_url = provider.bucket.generate_url(
+            100,
+            'POST',
+            query_parameters=query_params,
+            headers=headers
+        )
+        aiohttpretty.register_uri('POST', delete_url, params=query_params, status=200)
         await provider._delete_folder(path)
 
         # Verify list versions request was made
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
 
         # Verify delete calls were made for each version
-        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
-        assert len(delete_calls) == 3
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'POST']
+        assert len(delete_calls) == 1
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -1857,12 +1895,26 @@ class TestCRUD:
             ('111', 'large-folder/file1.txt'),
             ('222', 'large-folder/file2.txt')
         ]:
-            delete_url = provider.bucket.new_key(file_path).generate_url(
+            version_ids = {file_path: [version_id]
+                           }
+            payload_xml = prepare_xml_body(version_ids)
+            md5 = compute_md5(BytesIO(payload_xml))
+            headers = {
+                'Content-Length': str(len(payload_xml)),
+                'Content-MD5': md5[1],
+                'Content-Type': 'text/xml',
+            }
+
+            query_params = {'delete': ''}
+
+            # Mock delete requests for each version
+            delete_url = provider.bucket.generate_url(
                 100,
-                'DELETE',
-                query_parameters={'versionId': version_id}
+                'POST',
+                query_parameters=query_params,
+                headers=headers
             )
-            aiohttpretty.register_uri('DELETE', delete_url, status=204)
+            aiohttpretty.register_uri('POST', delete_url, params=query_params, status=200)
 
         await provider._delete_folder(path)
 
@@ -1871,7 +1923,7 @@ class TestCRUD:
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params2)
 
         # Verify delete calls were made for each version
-        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'DELETE']
+        delete_calls = [call for call in aiohttpretty.calls if call['method'] == 'POST']
         assert len(delete_calls) == 2
 
     @pytest.mark.asyncio
@@ -1931,19 +1983,32 @@ class TestCRUD:
         aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
 
         # Mock failed delete request
-        delete_url = provider.bucket.new_key('error-folder/file1.txt').generate_url(
+        version_ids = {'error-folder/file1.txt': ['111']}
+        payload_xml = prepare_xml_body(version_ids)
+        md5 = compute_md5(BytesIO(payload_xml))
+        headers = {
+            'Content-Length': str(len(payload_xml)),
+            'Content-MD5': md5[1],
+            'Content-Type': 'text/xml',
+        }
+
+        query_params = {'delete': ''}
+
+        # Mock delete requests for each version
+        delete_url = provider.bucket.generate_url(
             100,
-            'DELETE',
-            query_parameters={'versionId': '111'}
+            'POST',
+            query_parameters=query_params,
+            headers=headers
         )
-        aiohttpretty.register_uri('DELETE', delete_url, status=403)
+        aiohttpretty.register_uri('POST', delete_url, params=query_params, status=403)
 
         with pytest.raises(exceptions.DeleteError):
             await provider._delete_folder(path)
 
         # Verify both requests were made
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
-        assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
+        assert aiohttpretty.has_call(method='POST', uri=delete_url)
 
 
 class TestMetadata:

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -496,13 +496,34 @@ class S3Provider(provider.BaseProvider):
                 )
 
         if path.is_file:
-            resp = await self.make_request(
-                'DELETE',
-                self.bucket.new_key(path.path).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
-                expects=(200, 204, ),
-                throws=exceptions.DeleteError,
-            )
-            await resp.release()
+            # Check and delete all versions of the file
+            try:
+                versions = await self.revisions(path)
+                # Delete each version of the file
+                for version in versions:
+                    resp = await self.make_request(
+                        'DELETE',
+                        self.bucket.new_key(path.full_path).generate_url(
+                            settings.TEMP_URL_SECS,
+                            'DELETE',
+                            query_parameters={'versionId': version.raw['VersionId']}
+                        ),
+                        expects=(200, 204,),
+                        throws=exceptions.DeleteError,
+                    )
+                    await resp.release()
+
+            except exceptions.MetadataError:
+                # Skip if versions cannot be retrieved
+                # or if the file has no versions
+                # In this case, delete the current version directly
+                resp = await self.make_request(
+                    'DELETE',
+                    self.bucket.new_key(path.full_path).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
+                    expects=(200, 204,),
+                    throws=exceptions.DeleteError,
+                )
+                await resp.release()
         else:
             await self._delete_folder(path, **kwargs)
 
@@ -524,80 +545,84 @@ class S3Provider(provider.BaseProvider):
         objects.  Amazon provides a bulk delete operation to simplify this.
         """
         await self._check_region()
-
         more_to_come = True
         content_keys = []
-        query_params = {'prefix': path.path}
-        marker = None
+        query_params = {'prefix': path.path, 'versions': ''}
+        key_marker = None
+        version_marker = None
 
         while more_to_come:
-            if marker is not None:
-                query_params['marker'] = marker
+            if key_marker is not None:
+                query_params['key-marker'] = key_marker
+            if version_marker is not None:
+                query_params['version-id-marker'] = version_marker
 
             resp = await self.make_request(
                 'GET',
-                self.bucket.generate_url(settings.TEMP_URL_SECS, 'GET', query_parameters=query_params),
+                functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET', query_parameters=query_params),
                 params=query_params,
                 expects=(200, ),
                 throws=exceptions.MetadataError,
             )
 
             contents = await resp.read()
-            parsed = xmltodict.parse(contents, strip_whitespace=False)['ListBucketResult']
+            parsed = xmltodict.parse(contents, strip_whitespace=False)['ListVersionsResult']
             more_to_come = parsed.get('IsTruncated') == 'true'
-            contents = parsed.get('Contents', [])
 
-            if isinstance(contents, dict):
-                contents = [contents]
+            # Get both current versions and delete markers
+            versions = parsed.get('Version', [])
+            delete_markers = parsed.get('DeleteMarker', [])
 
-            content_keys.extend([content['Key'] for content in contents])
-            if len(content_keys) > 0:
-                marker = content_keys[-1]
+            if isinstance(versions, dict):
+                versions = [versions]
+            if isinstance(delete_markers, dict):
+                delete_markers = [delete_markers]
 
-        # Query against non-existant folder does not return 404
+            # Process versions and delete markers
+            for version in versions + delete_markers:
+                content_keys.append({
+                    'key': version['Key'],
+                    'version_id': version.get('VersionId')
+                })
+
+            if more_to_come:
+                key_marker = parsed.get('NextKeyMarker')
+                version_marker = parsed.get('NextVersionIdMarker')
+                if not key_marker and not version_marker:
+                    more_to_come = False
+
+        # Query against non-existent folder does not return 404
         if len(content_keys) == 0:
             raise exceptions.NotFoundError(str(path))
 
-        while len(content_keys) > 0:
-            key_batch = content_keys[:1000]
-            del content_keys[:1000]
-
-            payload = '<?xml version="1.0" encoding="UTF-8"?>'
-            payload += '<Delete>'
-            payload += ''.join(map(
-                lambda x: '<Object><Key>{}</Key></Object>'.format(xml.sax.saxutils.escape(x)),
-                key_batch
-            ))
-            payload += '</Delete>'
-            payload = payload.encode('utf-8')
-            md5 = compute_md5(BytesIO(payload))
-
-            query_params = {'delete': ''}
-            headers = {
-                'Content-Length': str(len(payload)),
-                'Content-MD5': md5[1],
-                'Content-Type': 'text/xml',
-            }
-
-            # We depend on a customized version of boto that can make query parameters part of
-            # the signature.
-            url = functools.partial(
-                self.bucket.generate_url,
-                settings.TEMP_URL_SECS,
-                'POST',
-                query_parameters=query_params,
-                headers=headers,
-            )
-            resp = await self.make_request(
-                'POST',
-                url,
-                params=query_params,
-                data=payload,
-                headers=headers,
-                expects=(200, 204, ),
-                throws=exceptions.DeleteError,
-            )
-            await resp.release()
+        # Delete all versions of each object
+        for content in content_keys[::-1]:
+            try:
+                if content['version_id'] is not None:
+                    # Delete specific version
+                    resp = await self.make_request(
+                        'DELETE',
+                        self.bucket.new_key(content['key']).generate_url(
+                            settings.TEMP_URL_SECS,
+                            'DELETE',
+                            query_parameters={'versionId': content['version_id']}
+                        ),
+                        expects=(200, 204, ),
+                        throws=exceptions.DeleteError,
+                    )
+                else:
+                    # Delete current version if version_id is not specified
+                    resp = await self.make_request(
+                        'DELETE',
+                        self.bucket.new_key(content['key']).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
+                        expects=(200, 204, ),
+                        throws=exceptions.DeleteError,
+                    )
+                await resp.release()
+            except exceptions.DeleteError as e:
+                logger.warning('Failed to delete object: key={}, version_id={}, error={}'.format(
+                    content['key'], content['version_id'], str(e)))
+                raise
 
     async def revisions(self, path, **kwargs):
         """Get past versions of the requested key

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -26,6 +26,26 @@ from waterbutler.providers.s3.metadata import (S3Revision,
 logger = logging.getLogger(__name__)
 
 
+def prepare_xml_body(object_dict):
+    """
+    Prepare xml body for call delete api
+    :param object_dict: The dictionary of key and version_id
+    :return: The xml body base on content of object_dict
+    """
+    payload = '<?xml version="1.0" encoding="UTF-8"?>'
+    payload += '<Delete>'
+    payload += ''.join(
+        '<Object><Key>{}</Key><VersionId>{}</VersionId></Object>'.format(
+            xml.sax.saxutils.escape(key), xml.sax.saxutils.escape(version)
+        )
+        for key, value in object_dict.items()
+        for version in value
+    )
+    payload += '</Delete>'
+    payload = payload.encode('utf-8')
+    return payload
+
+
 class S3Provider(provider.BaseProvider):
     """Provider for Amazon's S3 cloud storage service.
 
@@ -498,16 +518,40 @@ class S3Provider(provider.BaseProvider):
         if path.is_file:
             # Check and delete all versions of the file
             try:
-                versions = await self.revisions(path)
-                # Delete each version of the file
-                for version in versions:
+                prefix = path.full_path.lstrip('/')  # '/' -> '', '/A/B' -> 'A/B'
+                # "versions" in "query_parameters" is required for generate_url().
+                # SignatureDoesNotMatch is returned when "versions" is not specified.
+                query_params = {'prefix': prefix, 'delimiter': '/', 'versions': ''}
+                _, versions, delete_markers = await self.get_full_revision(query_params)
+                full_version_list = versions + delete_markers
+                if len(full_version_list) > 0:
+                    version_dict = {path.full_path: [version.get('VersionId') for version in full_version_list]}
+                    payload_version = prepare_xml_body(version_dict)
+                    # Delete all versions of each object
+                    md5 = compute_md5(BytesIO(payload_version))
+
+                    query_params = {'delete': ''}
+                    headers = {
+                        'Content-Length': str(len(payload_version)),
+                        'Content-MD5': md5[1],
+                        'Content-Type': 'text/xml',
+                    }
+
+                    # We depend on a customized version of boto that can make query parameters part of
+                    # the signature.
+                    url = functools.partial(
+                        self.bucket.generate_url,
+                        settings.TEMP_URL_SECS,
+                        'POST',
+                        query_parameters=query_params,
+                        headers=headers,
+                    )
                     resp = await self.make_request(
-                        'DELETE',
-                        self.bucket.new_key(path.full_path).generate_url(
-                            settings.TEMP_URL_SECS,
-                            'DELETE',
-                            query_parameters={'versionId': version.raw['VersionId']}
-                        ),
+                        'POST',
+                        url,
+                        params=query_params,
+                        data=payload_version,
+                        headers=headers,
                         expects=(200, 204,),
                         throws=exceptions.DeleteError,
                     )
@@ -546,27 +590,19 @@ class S3Provider(provider.BaseProvider):
         """
         await self._check_region()
         more_to_come = True
-        content_keys = []
         query_params = {'prefix': path.path, 'versions': ''}
         key_marker = None
         version_marker = None
-
+        content_dicts = {}
+        content_dicts_list = []
         while more_to_come:
+            content_dicts = {}
             if key_marker is not None:
                 query_params['key-marker'] = key_marker
             if version_marker is not None:
                 query_params['version-id-marker'] = version_marker
 
-            resp = await self.make_request(
-                'GET',
-                functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET', query_parameters=query_params),
-                params=query_params,
-                expects=(200, ),
-                throws=exceptions.MetadataError,
-            )
-
-            contents = await resp.read()
-            parsed = xmltodict.parse(contents, strip_whitespace=False)['ListVersionsResult']
+            parsed, versions, delete_markers = await self.get_full_revision(query_params)
             more_to_come = parsed.get('IsTruncated') == 'true'
 
             # Get both current versions and delete markers
@@ -580,10 +616,9 @@ class S3Provider(provider.BaseProvider):
 
             # Process versions and delete markers
             for version in versions + delete_markers:
-                content_keys.append({
-                    'key': version['Key'],
-                    'version_id': version.get('VersionId')
-                })
+                content_dicts.setdefault(version['Key'], []).append(version.get('VersionId'))
+            if len(content_dicts) > 0:
+                content_dicts_list.append(content_dicts)
 
             if more_to_come:
                 key_marker = parsed.get('NextKeyMarker')
@@ -592,37 +627,67 @@ class S3Provider(provider.BaseProvider):
                     more_to_come = False
 
         # Query against non-existent folder does not return 404
-        if len(content_keys) == 0:
+        if len(content_dicts) == 0:
             raise exceptions.NotFoundError(str(path))
+        for content_dicts in content_dicts_list:
+            # Delete all versions of each object
+            payload_version = prepare_xml_body(content_dicts)
+            # Delete new function
+            md5 = compute_md5(BytesIO(payload_version))
 
-        # Delete all versions of each object
-        for content in content_keys[::-1]:
-            try:
-                if content['version_id'] is not None:
-                    # Delete specific version
-                    resp = await self.make_request(
-                        'DELETE',
-                        self.bucket.new_key(content['key']).generate_url(
-                            settings.TEMP_URL_SECS,
-                            'DELETE',
-                            query_parameters={'versionId': content['version_id']}
-                        ),
-                        expects=(200, 204, ),
-                        throws=exceptions.DeleteError,
-                    )
-                else:
-                    # Delete current version if version_id is not specified
-                    resp = await self.make_request(
-                        'DELETE',
-                        self.bucket.new_key(content['key']).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
-                        expects=(200, 204, ),
-                        throws=exceptions.DeleteError,
-                    )
-                await resp.release()
-            except exceptions.DeleteError as e:
-                logger.warning('Failed to delete object: key={}, version_id={}, error={}'.format(
-                    content['key'], content['version_id'], str(e)))
-                raise
+            query_params = {'delete': ''}
+            headers = {
+                'Content-Length': str(len(payload_version)),
+                'Content-MD5': md5[1],
+                'Content-Type': 'text/xml',
+            }
+
+            # We depend on a customized version of boto that can make query parameters part of
+            # the signature.
+            url = functools.partial(
+                self.bucket.generate_url,
+                settings.TEMP_URL_SECS,
+                'POST',
+                query_parameters=query_params,
+                headers=headers,
+            )
+            resp = await self.make_request(
+                'POST',
+                url,
+                params=query_params,
+                data=payload_version,
+                headers=headers,
+                expects=(200, 204,),
+                throws=exceptions.DeleteError,
+            )
+            await resp.release()
+
+    async def get_full_revision(self, query_params):
+        """
+        Get all versions and delete markers of the requested object
+        :param query_params: The query parameters to be used in the request
+        :return: The dict of response content, list versions and delete_markers
+        """
+        resp = await self.make_request(
+            'GET',
+            functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET', query_parameters=query_params),
+            params=query_params,
+            expects=(200,),
+            throws=exceptions.MetadataError,
+        )
+
+        contents = await resp.read()
+        parsed = xmltodict.parse(contents, strip_whitespace=False)['ListVersionsResult']
+
+        # Get both current versions and delete markers
+        versions = parsed.get('Version', [])
+        delete_markers = parsed.get('DeleteMarker', [])
+
+        if isinstance(versions, dict):
+            versions = [versions]
+        if isinstance(delete_markers, dict):
+            delete_markers = [delete_markers]
+        return parsed, versions, delete_markers
 
     async def revisions(self, path, **kwargs):
         """Get past versions of the requested key

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -27,6 +27,25 @@ from waterbutler.providers.s3compat.metadata import (S3CompatRevision,
 logger = logging.getLogger(__name__)
 
 
+def prepare_xml_body(object_dict):
+    """
+    Prepare xml body for call delete api
+    :param object_dict: The dictionary of key and version_id
+    :return: The xml body base on content of object_dict
+    """
+    payload = '<?xml version="1.0" encoding="UTF-8"?>'
+    payload += '<Delete>'
+    payload += ''.join(
+        '<Object><Key>{}</Key><VersionId>{}</VersionId></Object>'.format(xml.sax.saxutils.escape(key),
+                                                                         xml.sax.saxutils.escape(version))
+        for key, value in object_dict.items()
+        for version in value
+    )
+    payload += '</Delete>'
+    payload = payload.encode('utf-8')
+    return payload
+
+
 class S3CompatConnection(S3Connection):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
@@ -37,14 +56,14 @@ class S3CompatConnection(S3Connection):
                  suppress_consec_slashes=True, anon=False,
                  validate_certs=None, profile_name=None):
         super(S3CompatConnection, self).__init__(aws_access_key_id,
-                aws_secret_access_key,
-                is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
-                host=host,
-                debug=debug, https_connection_factory=https_connection_factory,
-                calling_format=calling_format,
-                path=path, provider=provider, bucket_class=bucket_class,
-                security_token=security_token, anon=anon,
-                validate_certs=validate_certs, profile_name=profile_name)
+                                                 aws_secret_access_key,
+                                                 is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
+                                                 host=host,
+                                                 debug=debug, https_connection_factory=https_connection_factory,
+                                                 calling_format=calling_format,
+                                                 path=path, provider=provider, bucket_class=bucket_class,
+                                                 security_token=security_token, anon=anon,
+                                                 validate_certs=validate_certs, profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['s3']
@@ -112,14 +131,14 @@ class S3CompatProvider(provider.BaseProvider):
                 'GET',
                 functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET'),
                 params=params,
-                expects=(200, 404, ),
+                expects=(200, 404,),
                 throws=exceptions.MetadataError,
             )
         else:
             resp = await self.make_request(
                 'HEAD',
                 functools.partial(self.bucket.new_key(prefix).generate_url, settings.TEMP_URL_SECS, 'HEAD'),
-                expects=(200, 404, ),
+                expects=(200, 404,),
                 throws=exceptions.MetadataError,
             )
 
@@ -163,7 +182,7 @@ class S3CompatProvider(provider.BaseProvider):
             'PUT', url,
             skip_auto_headers={'CONTENT-TYPE'},
             headers=headers,
-            expects=(200, ),
+            expects=(200,),
             throws=exceptions.IntraCopyError,
         )
 
@@ -325,7 +344,7 @@ class S3CompatProvider(provider.BaseProvider):
             data=stream,
             skip_auto_headers={'CONTENT-TYPE'},
             headers=headers,
-            expects=(200, 201, ),
+            expects=(200, 201,),
             throws=exceptions.UploadError,
         )
         await resp.release()
@@ -603,16 +622,40 @@ class S3CompatProvider(provider.BaseProvider):
         if path.is_file:
             # Check and delete all versions of the file
             try:
-                versions = await self.revisions(path)
-                # Delete each version of the file
-                for version in versions:
+                prefix = path.full_path.lstrip('/')  # '/' -> '', '/A/B' -> 'A/B'
+                # "versions" in "query_parameters" is required for generate_url().
+                # SignatureDoesNotMatch is returned when "versions" is not specified.
+                query_params = {'prefix': prefix, 'delimiter': '/', 'versions': ''}
+                _, versions, delete_markers = await self.get_full_revision(query_params)
+                full_version_list = versions + delete_markers
+                if len(full_version_list) > 0:
+                    version_dict = {path.full_path: [version.get('VersionId') for version in full_version_list]}
+                    payload_version = prepare_xml_body(version_dict)
+                    # Delete all versions of each object
+                    md5 = compute_md5(BytesIO(payload_version))
+
+                    query_params = {'delete': ''}
+                    headers = {
+                        'Content-Length': str(len(payload_version)),
+                        'Content-MD5': md5[1],
+                        'Content-Type': 'text/xml',
+                    }
+
+                    # We depend on a customized version of boto that can make query parameters part of
+                    # the signature.
+                    url = functools.partial(
+                        self.bucket.generate_url,
+                        settings.TEMP_URL_SECS,
+                        'POST',
+                        query_parameters=query_params,
+                        headers=headers,
+                    )
                     resp = await self.make_request(
-                        'DELETE',
-                        self.bucket.new_key(path.full_path).generate_url(
-                            settings.TEMP_URL_SECS,
-                            'DELETE',
-                            query_parameters={'versionId': version.raw['VersionId']}
-                        ),
+                        'POST',
+                        url,
+                        params=query_params,
+                        data=payload_version,
+                        headers=headers,
                         expects=(200, 204,),
                         throws=exceptions.DeleteError,
                     )
@@ -642,7 +685,7 @@ class S3CompatProvider(provider.BaseProvider):
             'GET',
             self.bucket.generate_url(settings.TEMP_URL_SECS, 'GET'),
             params=query_params,
-            expects=(200, ),
+            expects=(200,),
             throws=exceptions.MetadataError,
         )
         contents = await resp.read()
@@ -677,46 +720,26 @@ class S3CompatProvider(provider.BaseProvider):
             raise exceptions.InvalidParameters('not a folder: {}'.format(str(path)))
 
         more_to_come = True
-        content_keys = []
         prefix = path.full_path.lstrip('/')  # '/' -> '', '/A/B/' -> 'A/B/'
         query_params = {'prefix': prefix, 'versions': ''}
         key_marker = None
         version_marker = None
-
+        content_dicts = {}
+        content_dicts_list = []
         while more_to_come:
+            content_dicts = {}
             if key_marker is not None:
                 query_params['key-marker'] = key_marker
             if version_marker is not None:
                 query_params['version-id-marker'] = version_marker
 
-            resp = await self.make_request(
-                'GET',
-                functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET', query_parameters=query_params),
-                params=query_params,
-                expects=(200, ),
-                throws=exceptions.MetadataError,
-            )
-
-            contents = await resp.read()
-            parsed = xmltodict.parse(contents, strip_whitespace=False)['ListVersionsResult']
+            parsed, versions, delete_markers = await self.get_full_revision(query_params)
             more_to_come = parsed.get('IsTruncated') == 'true'
-
-            # Get both current versions and delete markers
-            versions = parsed.get('Version', [])
-            delete_markers = parsed.get('DeleteMarker', [])
-
-            if isinstance(versions, dict):
-                versions = [versions]
-            if isinstance(delete_markers, dict):
-                delete_markers = [delete_markers]
-
             # Process versions and delete markers
             for version in versions + delete_markers:
-                content_keys.append({
-                    'key': version['Key'],
-                    'version_id': version.get('VersionId')
-                })
-
+                content_dicts.setdefault(version['Key'], []).append(version.get('VersionId'))
+            if len(content_dicts) > 0:
+                content_dicts_list.append(content_dicts)
             if more_to_come:
                 key_marker = parsed.get('NextKeyMarker')
                 version_marker = parsed.get('NextVersionIdMarker')
@@ -724,41 +747,71 @@ class S3CompatProvider(provider.BaseProvider):
                     more_to_come = False
 
         # Query against non-existent folder does not return 404
-        if len(content_keys) == 0:
+        if len(content_dicts) == 0:
             # MinIO cannot return Contents with a leaf folder itself.
             if await self._folder_prefix_exists(prefix):
-                content_keys = [{'key': prefix, 'version_id': None}]
+                content_dicts = {prefix, None}
+                content_dicts_list.append(content_dicts)
             else:
                 raise exceptions.NotFoundError(str(path))
 
-        # Delete all versions of each object
-        for content in content_keys[::-1]:
-            try:
-                if content['version_id'] is not None:
-                    # Delete specific version
-                    resp = await self.make_request(
-                        'DELETE',
-                        self.bucket.new_key(content['key']).generate_url(
-                            settings.TEMP_URL_SECS,
-                            'DELETE',
-                            query_parameters={'versionId': content['version_id']}
-                        ),
-                        expects=(200, 204, ),
-                        throws=exceptions.DeleteError,
-                    )
-                else:
-                    # Delete current version if version_id is not specified
-                    resp = await self.make_request(
-                        'DELETE',
-                        self.bucket.new_key(content['key']).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
-                        expects=(200, 204, ),
-                        throws=exceptions.DeleteError,
-                    )
-                await resp.release()
-            except exceptions.DeleteError as e:
-                logger.warning('Failed to delete object: key={}, version_id={}, error={}'.format(
-                    content['key'], content['version_id'], str(e)))
-                raise
+        for content_dicts in content_dicts_list:
+            # Delete all versions of each object
+            payload_version = prepare_xml_body(content_dicts)
+            # Delete new function
+            md5 = compute_md5(BytesIO(payload_version))
+
+            query_params = {'delete': ''}
+            headers = {
+                'Content-Length': str(len(payload_version)),
+                'Content-MD5': md5[1],
+                'Content-Type': 'text/xml',
+            }
+
+            # We depend on a customized version of boto that can make query parameters part of
+            # the signature.
+            url = functools.partial(
+                self.bucket.generate_url,
+                settings.TEMP_URL_SECS,
+                'POST',
+                query_parameters=query_params,
+                headers=headers,
+            )
+            resp = await self.make_request(
+                'POST',
+                url,
+                params=query_params,
+                data=payload_version,
+                headers=headers,
+                expects=(200, 204,),
+                throws=exceptions.DeleteError,
+            )
+            await resp.release()
+
+    async def get_full_revision(self, query_params):
+        """
+        Get all versions and delete markers of the requested object
+        :param query_params: The query parameters to be used in the request
+        :return: The dict of response content, list versions and delete_markers
+        """
+        resp = await self.make_request(
+            'GET',
+            functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET', query_parameters=query_params),
+            params=query_params,
+            expects=(200,),
+            throws=exceptions.MetadataError,
+        )
+
+        contents = await resp.read()
+        parsed = xmltodict.parse(contents, strip_whitespace=False)['ListVersionsResult']
+        versions = parsed.get('Version', [])
+        delete_markers = parsed.get('DeleteMarker', [])
+
+        if isinstance(versions, dict):
+            versions = [versions]
+        if isinstance(delete_markers, dict):
+            delete_markers = [delete_markers]
+        return parsed, versions, delete_markers
 
     async def revisions(self, path, **kwargs):
         """Get past versions of the requested key
@@ -829,11 +882,11 @@ class S3CompatProvider(provider.BaseProvider):
                 raise exceptions.FolderNamingConflict(path.name)
 
         async with self.request(
-            'PUT',
-            functools.partial(self.bucket.new_key(path.full_path).generate_url, settings.TEMP_URL_SECS, 'PUT'),
-            skip_auto_headers={'CONTENT-TYPE'},
-            expects=(200, 201, ),
-            throws=exceptions.CreateFolderError
+                'PUT',
+                functools.partial(self.bucket.new_key(path.full_path).generate_url, settings.TEMP_URL_SECS, 'PUT'),
+                skip_auto_headers={'CONTENT-TYPE'},
+                expects=(200, 201,),
+                throws=exceptions.CreateFolderError
         ):
             return S3CompatFolderMetadata(self, {'Prefix': path.full_path})
 
@@ -848,7 +901,7 @@ class S3CompatProvider(provider.BaseProvider):
                 'HEAD',
                 query_parameters={'versionId': revision} if revision else None
             ),
-            expects=(200, ),
+            expects=(200,),
             throws=exceptions.MetadataError,
         )
         await resp.release()
@@ -863,7 +916,7 @@ class S3CompatProvider(provider.BaseProvider):
             'GET',
             functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET'),
             params=params,
-            expects=(200, ),
+            expects=(200,),
             throws=exceptions.MetadataError,
         )
 
@@ -882,7 +935,7 @@ class S3CompatProvider(provider.BaseProvider):
             resp = await self.make_request(
                 'HEAD',
                 functools.partial(self.bucket.new_key(prefix).generate_url, settings.TEMP_URL_SECS, 'HEAD'),
-                expects=(200, ),
+                expects=(200,),
                 throws=exceptions.MetadataError,
             )
             await resp.release()

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -10,7 +10,6 @@ import xmltodict
 
 from boto.compat import BytesIO  # type: ignore
 from boto.s3.connection import S3Connection, OrdinaryCallingFormat, NoHostProvided
-from boto.connection import HTTPRequest
 from boto.s3.bucket import Bucket
 from boto.utils import compute_md5
 
@@ -46,14 +45,6 @@ class S3CompatConnection(S3Connection):
                 path=path, provider=provider, bucket_class=bucket_class,
                 security_token=security_token, anon=anon,
                 validate_certs=validate_certs, profile_name=profile_name)
-
-    def add_auth(self, method, url, headers):
-        urlo = parse.urlparse(url)
-        self._auth_handler.add_auth(HTTPRequest(method, urlo.scheme,
-                                                urlo.hostname, self.port,
-                                                urlo.path, urlo.path, {},
-                                                headers, ''))
-        return url[:url.index('?')] if '?' in url else url
 
     def _required_auth_capability(self):
         return ['s3']
@@ -256,11 +247,9 @@ class S3CompatProvider(provider.BaseProvider):
         )
 
         headers = {}
-        raw_url = self.connection.add_auth('GET', url('GET'), headers)
-
         resp = await self.make_request(
             'GET',
-            raw_url,
+            url,
             range=range,
             headers=headers,
             expects=(200, 206),
@@ -599,7 +588,7 @@ class S3CompatProvider(provider.BaseProvider):
         await resp.release()
 
     async def delete(self, path, confirm_delete=0, **kwargs):
-        """Deletes the key at the specified path
+        """Delete the key and all its versions at the specified path
 
         :param path: ( :class:`.WaterButlerPath` ) The path of the key to delete
         :param int confirm_delete: Must be 1 to confirm root folder delete
@@ -612,13 +601,34 @@ class S3CompatProvider(provider.BaseProvider):
                 )
 
         if path.is_file:
-            resp = await self.make_request(
-                'DELETE',
-                self.bucket.new_key(path.full_path).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
-                expects=(200, 204, ),
-                throws=exceptions.DeleteError,
-            )
-            await resp.release()
+            # Check and delete all versions of the file
+            try:
+                versions = await self.revisions(path)
+                # Delete each version of the file
+                for version in versions:
+                    resp = await self.make_request(
+                        'DELETE',
+                        self.bucket.new_key(path.full_path).generate_url(
+                            settings.TEMP_URL_SECS,
+                            'DELETE',
+                            query_parameters={'versionId': version.raw['VersionId']}
+                        ),
+                        expects=(200, 204,),
+                        throws=exceptions.DeleteError,
+                    )
+                    await resp.release()
+
+            except exceptions.MetadataError:
+                # Skip if versions cannot be retrieved
+                # or if the file has no versions
+                # In this case, delete the current version directly
+                resp = await self.make_request(
+                    'DELETE',
+                    self.bucket.new_key(path.full_path).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
+                    expects=(200, 204,),
+                    throws=exceptions.DeleteError,
+                )
+                await resp.release()
         else:
             await self._delete_folder(path, **kwargs)
 
@@ -665,52 +675,84 @@ class S3CompatProvider(provider.BaseProvider):
         """
         if not path.full_path.endswith('/'):
             raise exceptions.InvalidParameters('not a folder: {}'.format(str(path)))
+
         more_to_come = True
         content_keys = []
         prefix = path.full_path.lstrip('/')  # '/' -> '', '/A/B/' -> 'A/B/'
-        query_params = {'prefix': prefix}
+        query_params = {'prefix': prefix, 'versions': ''}
         marker = None
 
         while more_to_come:
             if marker is not None:
                 query_params['marker'] = marker
-
+            url = functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET', query_parameters=query_params)
             resp = await self.make_request(
                 'GET',
-                self.bucket.generate_url(settings.TEMP_URL_SECS, 'GET'),
+                url,
                 params=query_params,
                 expects=(200, ),
                 throws=exceptions.MetadataError,
             )
 
             contents = await resp.read()
-            parsed = xmltodict.parse(contents, strip_whitespace=False)['ListBucketResult']
+            parsed = xmltodict.parse(contents, strip_whitespace=False)['ListVersionsResult']
             more_to_come = parsed.get('IsTruncated') == 'true'
-            contents = parsed.get('Contents', [])
 
-            if isinstance(contents, dict):
-                contents = [contents]
+            # Get both current versions and delete markers
+            versions = parsed.get('Version', [])
+            delete_markers = parsed.get('DeleteMarker', [])
 
-            content_keys.extend([content['Key'] for content in contents])
-            if len(content_keys) > 0:
-                marker = content_keys[-1]
+            if isinstance(versions, dict):
+                versions = [versions]
+            if isinstance(delete_markers, dict):
+                delete_markers = [delete_markers]
 
-        # Query against non-existant folder does not return 404
+            # Process versions and delete markers
+            for version in versions + delete_markers:
+                content_keys.append({
+                    'key': version['Key'],
+                    'version_id': version.get('VersionId')
+                })
+
+            if more_to_come:
+                marker = parsed.get('NextKeyMarker')
+
+        # Query against non-existent folder does not return 404
         if len(content_keys) == 0:
             # MinIO cannot return Contents with a leaf folder itself.
             if await self._folder_prefix_exists(prefix):
-                content_keys = [prefix]
+                content_keys = [{'key': prefix, 'version_id': None}]
             else:
                 raise exceptions.NotFoundError(str(path))
 
-        for content_key in content_keys[::-1]:
-            resp = await self.make_request(
-                'DELETE',
-                self.bucket.new_key(content_key).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
-                expects=(200, 204, ),
-                throws=exceptions.DeleteError,
-            )
-            await resp.release()
+        # Delete all versions of each object
+        for content in content_keys[::-1]:
+            try:
+                if content['version_id'] is not None:
+                    # Delete specific version
+                    resp = await self.make_request(
+                        'DELETE',
+                        self.bucket.new_key(content['key']).generate_url(
+                            settings.TEMP_URL_SECS,
+                            'DELETE',
+                            query_parameters={'versionId': content['version_id']}
+                        ),
+                        expects=(200, 204, ),
+                        throws=exceptions.DeleteError,
+                    )
+                else:
+                    # Delete current version if version_id is not specified
+                    resp = await self.make_request(
+                        'DELETE',
+                        self.bucket.new_key(content['key']).generate_url(settings.TEMP_URL_SECS, 'DELETE'),
+                        expects=(200, 204, ),
+                        throws=exceptions.DeleteError,
+                    )
+                await resp.release()
+            except exceptions.DeleteError as e:
+                logger.warning('Failed to delete object: key={}, version_id={}, error={}'.format(
+                    content['key'], content['version_id'], str(e)))
+                raise
 
     async def revisions(self, path, **kwargs):
         """Get past versions of the requested key

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -56,14 +56,14 @@ class S3CompatConnection(S3Connection):
                  suppress_consec_slashes=True, anon=False,
                  validate_certs=None, profile_name=None):
         super(S3CompatConnection, self).__init__(aws_access_key_id,
-                                                 aws_secret_access_key,
-                                                 is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
-                                                 host=host,
-                                                 debug=debug, https_connection_factory=https_connection_factory,
-                                                 calling_format=calling_format,
-                                                 path=path, provider=provider, bucket_class=bucket_class,
-                                                 security_token=security_token, anon=anon,
-                                                 validate_certs=validate_certs, profile_name=profile_name)
+                aws_secret_access_key,
+                is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
+                host=host,
+                debug=debug, https_connection_factory=https_connection_factory,
+                calling_format=calling_format,
+                path=path, provider=provider, bucket_class=bucket_class,
+                security_token=security_token, anon=anon,
+                validate_certs=validate_certs, profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['s3']
@@ -131,14 +131,14 @@ class S3CompatProvider(provider.BaseProvider):
                 'GET',
                 functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET'),
                 params=params,
-                expects=(200, 404,),
+                expects=(200, 404, ),
                 throws=exceptions.MetadataError,
             )
         else:
             resp = await self.make_request(
                 'HEAD',
                 functools.partial(self.bucket.new_key(prefix).generate_url, settings.TEMP_URL_SECS, 'HEAD'),
-                expects=(200, 404,),
+                expects=(200, 404, ),
                 throws=exceptions.MetadataError,
             )
 
@@ -182,7 +182,7 @@ class S3CompatProvider(provider.BaseProvider):
             'PUT', url,
             skip_auto_headers={'CONTENT-TYPE'},
             headers=headers,
-            expects=(200,),
+            expects=(200, ),
             throws=exceptions.IntraCopyError,
         )
 
@@ -344,7 +344,7 @@ class S3CompatProvider(provider.BaseProvider):
             data=stream,
             skip_auto_headers={'CONTENT-TYPE'},
             headers=headers,
-            expects=(200, 201,),
+            expects=(200, 201, ),
             throws=exceptions.UploadError,
         )
         await resp.release()
@@ -685,7 +685,7 @@ class S3CompatProvider(provider.BaseProvider):
             'GET',
             self.bucket.generate_url(settings.TEMP_URL_SECS, 'GET'),
             params=query_params,
-            expects=(200,),
+            expects=(200, ),
             throws=exceptions.MetadataError,
         )
         contents = await resp.read()
@@ -882,11 +882,11 @@ class S3CompatProvider(provider.BaseProvider):
                 raise exceptions.FolderNamingConflict(path.name)
 
         async with self.request(
-                'PUT',
-                functools.partial(self.bucket.new_key(path.full_path).generate_url, settings.TEMP_URL_SECS, 'PUT'),
-                skip_auto_headers={'CONTENT-TYPE'},
-                expects=(200, 201,),
-                throws=exceptions.CreateFolderError
+            'PUT',
+            functools.partial(self.bucket.new_key(path.full_path).generate_url, settings.TEMP_URL_SECS, 'PUT'),
+            skip_auto_headers={'CONTENT-TYPE'},
+            expects=(200, 201, ),
+            throws=exceptions.CreateFolderError
         ):
             return S3CompatFolderMetadata(self, {'Prefix': path.full_path})
 
@@ -901,7 +901,7 @@ class S3CompatProvider(provider.BaseProvider):
                 'HEAD',
                 query_parameters={'versionId': revision} if revision else None
             ),
-            expects=(200,),
+            expects=(200, ),
             throws=exceptions.MetadataError,
         )
         await resp.release()
@@ -916,7 +916,7 @@ class S3CompatProvider(provider.BaseProvider):
             'GET',
             functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET'),
             params=params,
-            expects=(200,),
+            expects=(200, ),
             throws=exceptions.MetadataError,
         )
 
@@ -935,7 +935,7 @@ class S3CompatProvider(provider.BaseProvider):
             resp = await self.make_request(
                 'HEAD',
                 functools.partial(self.bucket.new_key(prefix).generate_url, settings.TEMP_URL_SECS, 'HEAD'),
-                expects=(200,),
+                expects=(200, ),
                 throws=exceptions.MetadataError,
             )
             await resp.release()

--- a/waterbutler/providers/s3compat/provider.py
+++ b/waterbutler/providers/s3compat/provider.py
@@ -680,15 +680,18 @@ class S3CompatProvider(provider.BaseProvider):
         content_keys = []
         prefix = path.full_path.lstrip('/')  # '/' -> '', '/A/B/' -> 'A/B/'
         query_params = {'prefix': prefix, 'versions': ''}
-        marker = None
+        key_marker = None
+        version_marker = None
 
         while more_to_come:
-            if marker is not None:
-                query_params['marker'] = marker
-            url = functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET', query_parameters=query_params)
+            if key_marker is not None:
+                query_params['key-marker'] = key_marker
+            if version_marker is not None:
+                query_params['version-id-marker'] = version_marker
+
             resp = await self.make_request(
                 'GET',
-                url,
+                functools.partial(self.bucket.generate_url, settings.TEMP_URL_SECS, 'GET', query_parameters=query_params),
                 params=query_params,
                 expects=(200, ),
                 throws=exceptions.MetadataError,
@@ -715,7 +718,10 @@ class S3CompatProvider(provider.BaseProvider):
                 })
 
             if more_to_come:
-                marker = parsed.get('NextKeyMarker')
+                key_marker = parsed.get('NextKeyMarker')
+                version_marker = parsed.get('NextVersionIdMarker')
+                if not key_marker and not version_marker:
+                    more_to_come = False
 
         # Query against non-existent folder does not return 404
         if len(content_keys) == 0:


### PR DESCRIPTION
## Ticket

GRDM-50089

## Purpose

- Fix the issue of downloading/viewing file versions for the S3 Compatible Storage provider (Add-on method) when Bucket versioning is enabled.
- Fix the issue of deleting files when Bucket versioning is enabled.

## Changes

- S3 compatible storage (Add-on method): 
  - Remove add_auth function
  - Delete all file version when delete file
- Amazon S3 (Add-on method):
  - Delete all file version when delete file
## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
