### PR TITLE
[GRDM-52917]Fix properties do not display created at after file upload

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -653,7 +653,7 @@ class TestDelete:
         root_path = WaterButlerPath('/', _ids=('0'))
 
         url = provider.build_url('folders', root_path.identifier, 'items',
-                                 fields='id,name,size,modified_at,etag,total_count',
+                                 fields='id,name,size,modified_at,etag,total_count,created_at',
                                  offset=(0), limit=1000)
         aiohttpretty.register_json_uri('GET', url,
                                        body=root_provider_fixtures['one_entry_folder_list_metadata'])
@@ -750,7 +750,7 @@ class TestMetadata:
         path = WaterButlerPath('/', _ids=(provider.folder, ))
 
         list_url = provider.build_url('folders', provider.folder, 'items',
-                                      fields='id,name,size,modified_at,etag,total_count',
+                                      fields='id,name,size,modified_at,etag,total_count,created_at',
                                       offset=0, limit=1000)
 
         list_metadata = root_provider_fixtures['folder_list_metadata']
@@ -775,7 +775,7 @@ class TestMetadata:
         path = WaterButlerPath('/', _ids=(provider.folder, ))
 
         list_url = provider.build_url('folders', provider.folder, 'items',
-                                      fields='id,name,size,modified_at,etag,total_count',
+                                      fields='id,name,size,modified_at,etag,total_count,created_at',
                                       offset=0, limit=1000)
 
         aiohttpretty.register_json_uri('GET', list_url, body=item)
@@ -906,7 +906,7 @@ class TestIntraCopy:
 
         file_url = provider.build_url('folders', src_path.identifier, 'copy')
         list_url = provider.build_url('folders', item['id'], 'items',
-                                      fields='id,name,size,modified_at,etag,total_count',
+                                      fields='id,name,size,modified_at,etag,total_count,created_at',
                                       offset=0, limit=1000)
 
         aiohttpretty.register_json_uri('GET', list_url, body=list_metadata)
@@ -936,7 +936,7 @@ class TestIntraCopy:
         file_url = provider.build_url('folders', src_path.identifier, 'copy')
         delete_url = provider.build_url('folders', dest_path.identifier, recursive=True)
         list_url = provider.build_url('folders', item['id'], 'items',
-                                      fields='id,name,size,modified_at,etag,total_count',
+                                      fields='id,name,size,modified_at,etag,total_count,created_at',
                                       offset=0, limit=1000)
 
         aiohttpretty.register_json_uri('GET', list_url, body=list_metadata)
@@ -1002,7 +1002,7 @@ class TestIntraMove:
 
         file_url = provider.build_url('folders', src_path.identifier)
         list_url = provider.build_url('folders', item['id'], 'items',
-                                      fields='id,name,size,modified_at,etag,total_count',
+                                      fields='id,name,size,modified_at,etag,total_count,created_at',
                                       offset=0, limit=1000)
 
         aiohttpretty.register_json_uri('PUT', file_url, body=item)
@@ -1033,7 +1033,7 @@ class TestIntraMove:
         file_url = provider.build_url('folders', src_path.identifier)
         delete_url = provider.build_url('folders', dest_path.identifier, recursive=True)
         list_url = provider.build_url('folders', item['id'], 'items',
-                                      fields='id,name,size,modified_at,etag,total_count',
+                                      fields='id,name,size,modified_at,etag,total_count,created_at',
                                       offset=0, limit=1000)
 
         aiohttpretty.register_json_uri('PUT', file_url, body=item)

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -436,7 +436,7 @@ class BoxProvider(provider.BaseProvider):
         full_resp = {} if raw else []  # type: ignore
         while page_total is None or page_count < page_total:
             url = self.build_url('folders', path.identifier, 'items',
-                                 fields='id,name,size,modified_at,etag,total_count',
+                                 fields='id,name,size,modified_at,etag,total_count,created_at',
                                  offset=(page_count * limit),
                                  limit=limit)
             response = await self.make_request(

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -225,6 +225,7 @@ class OSFStorageProvider(provider.BaseProvider):
             'checkout': data['data']['checkout'],
             'modified': data['data']['modified'],
             'modified_utc': utils.normalize_datetime(data['data']['modified']),
+            'created_utc': utils.normalize_datetime(data['data']['created']),
         })
 
         path._parts[-1]._id = metadata['path'].strip('/')


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

GRDM-52917

## Purpose

- Institution storage (bulk-mount method): Fix "Created at" value not displayed on properties dialog after file upload.
- Extend storage (add-on method): Fix "Created at" value not displayed for Box provider.

## Changes

- osfstorage provider:  Add mapping data "created" to the response of the file upload API
- box provider: Add "created_at" parameter to receive from the provider.

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
