### PR TITLE
[GRDM-55759] Fix Debian Buster EOL repository issue in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM python:3.6-slim-buster
 RUN usermod -d /home www-data && chown www-data:www-data /home
 
 # Install dependancies
-RUN apt-get update \
+# Update sources for Debian Buster (EOL) to use archive
+RUN echo "deb https://archive.debian.org/debian buster main" > /etc/apt/sources.list \
+    && echo "deb https://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y \
         git \
         libevent-dev \


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->



<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

GRDM-55759

## Purpose

Dockerfileビルド時のエラー https://github.com/RCOSDP/RDM-modular-file-renderer/pull/7 参照への対処(案)です。

## Changes

リポジトリを切り替え: `archive.debian.org`

## Side effects

不明 - https://github.com/RCOSDP/RDM-e2e-test-nb/ でのE2Eテストではこのパッチを当てたイメージでテストを行えていました。

## QA Notes

None

## Deployment Notes

None
