### PR TITLE
skip s3 region checks by using stored region from addons

### DIFF
--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -63,7 +63,7 @@ class S3Provider(provider.BaseProvider):
                 credentials['secret_key'], calling_format=OrdinaryCallingFormat())
         self.bucket = self.connection.get_bucket(settings['bucket'], validate=False)
         self.encrypt_uploads = self.settings.get('encrypt_uploads', False)
-        self.region = None
+        self.region = self.settings.get('region', None)
 
     async def validate_v1_path(self, path, **kwargs):
         await self._check_region()
@@ -766,10 +766,10 @@ class S3Provider(provider.BaseProvider):
             if self.region == 'EU':
                 self.region = 'eu-west-1'
 
-            if self.region != '':
-                self.connection.host = self.connection.host.replace('s3.', 's3-' + self.region + '.', 1)
-                self.connection._auth_handler = get_auth_handler(
-                    self.connection.host, boto_config, self.connection.provider, self.connection._required_auth_capability())
+        if self.region != '':
+            self.connection.host = self.connection.host.replace('s3.', 's3-' + self.region + '.', 1)
+            self.connection._auth_handler = get_auth_handler(
+                self.connection.host, boto_config, self.connection.provider, self.connection._required_auth_capability())
 
         self.metrics.add('region', self.region)
 


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/55671
https://redmine.devops.rcos.nii.ac.jp/issues/55665

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose

S3プロバイダーを最適化し、リージョン情報を活用した効率的な接続を実現します。
不要なリージョン検出APIコールを削減
初回から正しいエンドポイントに接続
リージョン自動検出のオーバーヘッドを削減


## Changes

初期化時に設定からリージョン情報を取得
RDM-osf.io #612 で保存されたリージョン情報を活用
リージョン情報が利用可能な場合、最初から適切なS3エンドポイントを使用
_check_region() の結果を待たずに接続可能
インデント修正により、リージョンチェック後も適切にホストを設定

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

RDM-osf.io #612 → S3リージョン情報の保存とヘッダー追加
RDM-waterbutler #79 → リージョン情報の活用
RDM-modular-file-renderer #6 → メタデータキャッシュの活用
