### PR TITLE
S3互換ストレージ (SigV4) アドオンの追加

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             'azureblobstorage = waterbutler.providers.azureblobstorage:AzureBlobStorageProvider',
             'weko = waterbutler.providers.weko:WEKOProvider',
             's3compat = waterbutler.providers.s3compat:S3CompatProvider',
+            's3compatsigv4 = waterbutler.providers.s3compatsigv4:S3CompatSigV4Provider',
             's3compatb3 = waterbutler.providers.s3compatb3:S3CompatB3Provider',
             'nextcloud = waterbutler.providers.nextcloud:NextcloudProvider',
             'iqbrims = waterbutler.providers.iqbrims:IQBRIMSProvider',

--- a/tests/providers/s3compatsigv4/test_provider.py
+++ b/tests/providers/s3compatsigv4/test_provider.py
@@ -29,13 +29,6 @@ from waterbutler.providers.s3compatsigv4.metadata import (S3CompatSigV4Revision,
                                                      S3CompatSigV4FileMetadataHeaders,
                                                      )
 from hmac import compare_digest
-from waterbutler.providers.s3compatsigv4.provider import prepare_xml_body_batches
-
-
-def prepare_xml_body(object_dict):
-    """Helper to prepare XML body for delete operations - returns first batch"""
-    return next(prepare_xml_body_batches(object_dict))
-
 
 @pytest.fixture
 def base_prefix():
@@ -758,21 +751,6 @@ def list_upload_chunks_body(parts_metadata):
     }
 
     return payload, headers
-
-
-def prepare_xml_body(object_dict):
-    payload = '<?xml version="1.0" encoding="UTF-8"?>'
-    payload += '<Delete>'
-    payload += ''.join(
-        '<Object><Key>{}</Key><VersionId>{}</VersionId></Object>'.format(
-            xml.sax.saxutils.escape(key), xml.sax.saxutils.escape(version)
-        )
-        for key, value in object_dict.items()
-        for version in value
-    )
-    payload += '</Delete>'
-    payload = payload.encode('utf-8')
-    return payload
 
 
 class TestProviderConstruction:
@@ -2253,9 +2231,16 @@ class TestMetadata:
                 {'headers': file_header_metadata},
             ],
         )
-        aiohttpretty.register_uri('PUT', url, status=200, headers={'ETag': '"bad hash"'})
 
-        with pytest.raises(exceptions.UploadChecksumMismatchError):
+        error_body = '''<?xml version="1.0" encoding="UTF-8"?>
+        <Error>
+            <Code>InvalidDigest</Code>
+            <Message>The Content-Md5 you specified is not valid.</Message>
+        </Error>'''
+
+        aiohttpretty.register_uri('PUT', url, status=400, body=error_body)
+
+        with pytest.raises(exceptions.UploadError):
             await provider.upload(file_stream, path)
 
         assert aiohttpretty.has_call(method='PUT', uri=url)

--- a/tests/providers/s3compatsigv4/test_provider.py
+++ b/tests/providers/s3compatsigv4/test_provider.py
@@ -497,6 +497,33 @@ def folder_metadata(base_prefix):
 
 
 @pytest.fixture
+def folder_metadata_paginated(base_prefix):
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <Marker/>
+            <MaxKeys>1000</MaxKeys>
+            <IsTruncated>true</IsTruncated>
+            <NextContinuationToken>token-for-next-page</NextContinuationToken>
+            <Contents>
+                <Key>{prefix}my-image.jpg</Key>
+                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                <Size>434234</Size>
+                <StorageClass>STANDARD</StorageClass>
+                <Owner>
+                    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                    <DisplayName>mtd@amazon.com</DisplayName>
+                </Owner>
+            </Contents>
+            <CommonPrefixes>
+                <Prefix>{prefix}   photos/</Prefix>
+            </CommonPrefixes>
+        </ListBucketResult>'''.format(prefix=base_prefix)
+
+
+@pytest.fixture
 def folder_single_item_metadata(base_prefix):
     return'''<?xml version="1.0" encoding="UTF-8"?>
     <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -2043,14 +2070,15 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_have_next_token(self, provider, folder_metadata, mock_time, generate_url_helper):
+    async def test_metadata_empty_next_token_ignored(self, provider, folder_metadata, mock_time, generate_url_helper):
+        """Empty next_token should not send ContinuationToken to S3,
+        preventing InvalidArgument errors from the storage backend."""
         path = WaterButlerPath('/darp/')
         query_params = {
             'Prefix': path.full_path.lstrip('/'),
             'Delimiter': '/',
             'MaxKeys': 1000,
             'EncodingType': 'url',
-            'ContinuationToken': ''
         }
         url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
         params = {
@@ -2059,7 +2087,6 @@ class TestMetadata:
             'delimiter': '/',
             'max-keys': '1000',
             'encoding-type': 'url',
-            'continuation-token': ''
         }
 
         aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
@@ -2075,14 +2102,17 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_folder_have_next_token(self, provider, folder_metadata, mock_time, generate_url_helper):
+    async def test_metadata_folder_with_valid_continuation_token(self, provider, folder_metadata_paginated, mock_time, generate_url_helper):
+        """Valid next_token should be sent as ContinuationToken and the response
+        with NextContinuationToken should be handled correctly."""
         path = WaterButlerPath('/darp/')
+        token = 'abc123-valid-token'
         query_params = {
             'Prefix': path.full_path.lstrip('/'),
             'Delimiter': '/',
             'MaxKeys': 1000,
             'EncodingType': 'url',
-            'ContinuationToken': ''
+            'ContinuationToken': token,
         }
         url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
         params = {
@@ -2091,19 +2121,21 @@ class TestMetadata:
             'delimiter': '/',
             'max-keys': '1000',
             'encoding-type': 'url',
-            'continuation-token': ''
+            'continuation-token': token,
         }
 
-        aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata_paginated,
                                   headers={'Content-Type': 'application/xml'})
 
-        result = await provider._metadata_folder(path, next_token='')
+        result = await provider._metadata_folder(path, next_token=token)
 
         assert isinstance(result, list)
+        # 1 CommonPrefixes + 1 Contents + 1 next_token marker = 3 items
         assert len(result) == 3
         assert result[0].name == '   photos'
         assert result[1].name == 'my-image.jpg'
-        assert result[2].extra['md5'] == '1b2cf535f27731c974343645a3985328'
+        # Last item is the next_token marker for pagination
+        assert result[2].kind == 'folder'
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/tests/providers/s3compatsigv4/test_provider.py
+++ b/tests/providers/s3compatsigv4/test_provider.py
@@ -2130,12 +2130,12 @@ class TestMetadata:
         result = await provider._metadata_folder(path, next_token=token)
 
         assert isinstance(result, list)
-        # 1 CommonPrefixes + 1 Contents + 1 next_token marker = 3 items
+        # 1 CommonPrefixes + 1 Contents + 1 next_token string = 3 items
         assert len(result) == 3
         assert result[0].name == '   photos'
         assert result[1].name == 'my-image.jpg'
-        # Last item is the next_token marker for pagination
-        assert result[2].kind == 'folder'
+        # Last item is the next_token string for pagination
+        assert result[2] == 'token-for-next-page'
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/tests/providers/s3compatsigv4/test_provider.py
+++ b/tests/providers/s3compatsigv4/test_provider.py
@@ -1,0 +1,2502 @@
+import os
+import io
+import xml
+import json
+import time
+import base64
+import hashlib
+import datetime
+import aiohttpretty
+from http import client
+from urllib import parse
+from unittest import mock
+
+import pytest
+from boto.compat import BytesIO
+from boto.utils import compute_md5
+
+from waterbutler.core import streams, metadata, exceptions
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.providers.s3compatsigv4 import S3CompatSigV4Provider
+from waterbutler.providers.s3compatsigv4 import settings as pd_settings
+
+from tests.utils import MockCoroutine
+from collections import OrderedDict
+from waterbutler.providers.s3compatsigv4.metadata import (S3CompatSigV4Revision,
+                                                     S3CompatSigV4FileMetadata,
+                                                     S3CompatSigV4FolderMetadata,
+                                                     S3CompatSigV4FolderKeyMetadata,
+                                                     S3CompatSigV4FileMetadataHeaders,
+                                                     )
+from hmac import compare_digest
+from waterbutler.providers.s3compatsigv4.provider import prepare_xml_body_batches
+
+
+def prepare_xml_body(object_dict):
+    """Helper to prepare XML body for delete operations - returns first batch"""
+    return next(prepare_xml_body_batches(object_dict))
+
+
+@pytest.fixture
+def base_prefix():
+    return ''
+
+
+@pytest.fixture
+def auth():
+    return {
+        'name': 'cat',
+        'email': 'cat@cat.com',
+    }
+
+
+@pytest.fixture
+def credentials():
+    return {
+        'host': 'Target.Host',
+        'access_key': 'Dont dead',
+        'secret_key': 'open inside',
+    }
+
+
+@pytest.fixture
+def settings():
+    return {
+        'bucket': 'that_kerning',
+        'region': 'us-east-1',
+        'encrypt_uploads': False
+    }
+
+
+@pytest.fixture
+def mock_time(monkeypatch):
+    mock_time_value = mock.Mock(return_value=1454684930.0)
+    monkeypatch.setattr(time, 'time', mock_time_value)
+    
+    # Mock datetime for boto3/botocore signature generation
+    # 1454684930.0 corresponds to 2016-02-05 15:08:50 UTC
+    fixed_datetime = datetime.datetime(2016, 2, 5, 15, 8, 50, tzinfo=datetime.timezone.utc)
+    
+    class MockDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz:
+                return fixed_datetime
+            return fixed_datetime.replace(tzinfo=None)
+        
+        @classmethod
+        def utcnow(cls):
+            return fixed_datetime.replace(tzinfo=None)
+    
+    monkeypatch.setattr(datetime, 'datetime', MockDateTime)
+
+
+@pytest.fixture
+def provider(auth, credentials, settings):
+    return S3CompatSigV4Provider(auth, credentials, settings)
+
+
+@pytest.fixture
+def generate_url_helper(provider):
+    """Helper to generate presigned URLs for boto3-based S3CompatSigV4Provider
+    
+    """
+    def _generate_url(key=None, method='GET', expires=100, query_parameters=None, 
+                     response_headers=None, headers=None, encrypt_key=False):
+        """
+        Generate a presigned URL for S3CompatSigV4Provider
+        
+        :param key: S3 object key (None for bucket-level operations like list_objects)
+        :param method: HTTP method ('GET', 'HEAD', 'PUT', 'POST', 'DELETE')
+        :param expires: Expiration time in seconds
+        :param query_parameters: Additional query parameters dict (e.g., {'versions': '', 'delete': ''})
+        :param response_headers: Response headers dict for presigned URLs
+        :param headers: Request headers dict
+        :param encrypt_key: Whether to use encryption (adds SSE headers)
+        """
+        method_upper = method.upper()
+        
+        # Map HTTP method to boto3 client method
+        if key:
+            # Object-level operations
+            if method_upper == 'POST':
+                if query_parameters and any(k.lower() == 'delete' for k in query_parameters.keys()):
+                    client_method = 'delete_objects'
+                elif query_parameters and 'uploads' in query_parameters:
+                    client_method = 'create_multipart_upload'
+                elif query_parameters and 'uploadId' in query_parameters:
+                    client_method = 'complete_multipart_upload'
+                else:
+                    # Default POST operation (shouldn't happen in practice)
+                    client_method = 'put_object'
+            elif method_upper == 'DELETE':
+                # Check if this is an abort multipart upload
+                if query_parameters and 'uploadId' in query_parameters:
+                    client_method = 'abort_multipart_upload'
+                else:
+                    client_method = 'delete_object'
+            elif method_upper == 'GET':
+                # Check if this is a list parts operation
+                if query_parameters and 'uploadId' in query_parameters:
+                    client_method = 'list_parts'
+                else:
+                    client_method = 'get_object'
+            elif method_upper == 'PUT':
+                # Check if this is an upload part operation
+                if query_parameters and 'uploadId' in query_parameters and 'partNumber' in query_parameters:
+                    client_method = 'upload_part'
+                else:
+                    client_method = 'put_object'
+            else:
+                method_map = {
+                    'HEAD': 'head_object',
+                }
+                client_method = method_map.get(method_upper, 'get_object')
+            params = {'Bucket': provider.bucket_name, 'Key': key}
+        else:
+            # Bucket-level operations (list, bulk delete, etc.)
+            if query_parameters and 'versions' in query_parameters:
+                client_method = 'list_object_versions'
+            elif query_parameters and any(k.lower() == 'delete' for k in query_parameters.keys()):
+                client_method = 'delete_objects'
+            else:
+                client_method = 'list_objects_v2'
+            params = {'Bucket': provider.bucket_name}
+        
+        # Add query parameters to params
+        if query_parameters:
+            # Handle special query parameters
+            for key_param, value_param in query_parameters.items():
+                # Skip query params that are only used to determine the boto3 method
+                if key_param.lower() in ['versions', 'delete', 'uploads']:
+                    continue
+                # Convert S3 query parameter names to boto3 parameter names
+                if key_param == 'uploadId':
+                    params['UploadId'] = value_param
+                elif key_param == 'partNumber':
+                    params['PartNumber'] = int(value_param)
+                elif key_param in ['prefix', 'delimiter']:
+                    params[key_param.capitalize()] = value_param
+                elif key_param in ['Prefix', 'Delimiter', 'VersionIdMarker', 'KeyMarker', 'VersionId']:
+                    # Already in boto3 format
+                    params[key_param] = value_param
+                else:
+                    params[key_param] = value_param
+        
+        # Add response headers (for download URLs)
+        if response_headers:
+            for rh_key, rh_value in response_headers.items():
+                # Convert to boto3 format (e.g., 'response-content-disposition' -> 'ResponseContentDisposition')
+                param_key = ''.join(word.capitalize() for word in rh_key.replace('response-', '').split('-'))
+                param_key = 'Response' + param_key
+                params[param_key] = rh_value
+        
+        # Add encryption headers if needed
+        if encrypt_key or headers:
+            # Note: Encryption and custom headers in presigned URLs work differently in boto3
+            # They need to be included when making the request, not in the presigned URL itself
+            pass
+        
+        return provider.connection.generate_presigned_url(
+            client_method, Params=params, ExpiresIn=expires, HttpMethod=method_upper
+        )
+    
+    return _generate_url
+
+
+@pytest.fixture
+def file_content():
+    return b'sleepy'
+
+
+@pytest.fixture
+def file_like(file_content):
+    return io.BytesIO(file_content)
+
+
+@pytest.fixture
+def file_stream(file_like):
+    return streams.FileStreamReader(file_like)
+
+
+@pytest.fixture
+def file_header_metadata():
+    return {
+        'Content-Length': '9001',
+        'Last-Modified': 'SomeTime',
+        'Content-Type': 'binary/octet-stream',
+        'Etag': '"fba9dede5f27731c9771645a39863328"',
+        'x-amz-server-side-encryption': 'AES256'
+    }
+
+
+@pytest.fixture
+def file_metadata_headers_object(file_header_metadata):
+    return S3CompatSigV4FileMetadataHeaders('test-path', file_header_metadata)
+
+
+@pytest.fixture
+def file_metadata_object():
+    content = OrderedDict(Key='my-image.jpg',
+                          LastModified='2009-10-12T17:50:30.000Z',
+                          ETag="fba9dede5f27731c9771645a39863328",
+                          Size='434234',
+                          StorageClass='STANDARD')
+
+    return S3CompatSigV4FileMetadata(content)
+
+
+@pytest.fixture
+def folder_key_metadata_object():
+    content = OrderedDict(Key='naptime/folder/folder1',
+                          LastModified='2009-10-12T17:50:30.000Z',
+                          ETag='"fba9dede5f27731c9771645a39863328"',
+                          Size='0',
+                          StorageClass='STANDARD')
+
+    return S3CompatSigV4FolderKeyMetadata(content)
+
+
+@pytest.fixture
+def folder_metadata_object():
+    content = OrderedDict(Prefix='photos/',
+                          created_at='2009-10-12T17:50:30.000Z',
+                          updated_at='2009-10-12T17:50:30.000Z')
+    return S3CompatSigV4FolderMetadata(content)
+
+
+@pytest.fixture
+def revision_metadata_object():
+    content = OrderedDict(
+        Key='single-version.file',
+        VersionId='3/L4kqtJl40Nr8X8gdRQBpUMLUo',
+        IsLatest='true',
+        LastModified='2009-10-12T17:50:30.000Z',
+        ETag='"fba9dede5f27731c9771645a39863328"',
+        Size=434234,
+        StorageClass='STANDARD',
+        Owner=OrderedDict(
+            ID='75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a',
+            DisplayName='mtd@amazon.com'
+        )
+    )
+
+    return S3CompatSigV4Revision(content)
+
+
+@pytest.fixture
+def copy_object_resp():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <CopyObjectResult>
+        <ETag>string</ETag>
+        <LastModified>timestamp</LastModified>
+        <ChecksumCRC32>string</ChecksumCRC32>
+        <ChecksumCRC32C>string</ChecksumCRC32C>
+        <ChecksumSHA1>string</ChecksumSHA1>
+        <ChecksumSHA256>string</ChecksumSHA256>
+    </CopyObjectResult>'''
+
+
+@pytest.fixture
+def api_error_resp():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <Error>
+        <Code>Internal Error</Code>
+        <Message>Internal Error</Message>
+        <Resource>/object/path</Resource>
+        <RequestId>1234567890</RequestId>
+    </Error>'''
+
+
+@pytest.fixture
+def single_version_metadata():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
+        <Name>bucket</Name>
+        <Prefix>my</Prefix>
+        <KeyMarker/>
+        <VersionIdMarker/>
+        <MaxKeys>5</MaxKeys>
+        <IsTruncated>false</IsTruncated>
+        <Version>
+            <Key>single-version.file</Key>
+            <VersionId>3/L4kqtJl40Nr8X8gdRQBpUMLUo</VersionId>
+            <IsLatest>true</IsLatest>
+            <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+            <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+            <Size>434234</Size>
+            <StorageClass>STANDARD</StorageClass>
+            <Owner>
+                <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                <DisplayName>mtd@amazon.com</DisplayName>
+            </Owner>
+        </Version>
+    </ListVersionsResult>'''
+
+
+@pytest.fixture
+def version_metadata():
+    return b'''<?xml version="1.0" encoding="UTF-8"?>
+    <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
+        <Name>bucket</Name>
+        <Prefix>my</Prefix>
+        <KeyMarker/>
+        <VersionIdMarker/>
+        <MaxKeys>5</MaxKeys>
+        <IsTruncated>false</IsTruncated>
+        <Version>
+            <Key>my-image.jpg</Key>
+            <VersionId>3/L4kqtJl40Nr8X8gdRQBpUMLUo</VersionId>
+            <IsLatest>true</IsLatest>
+            <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+            <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+            <Size>434234</Size>
+            <StorageClass>STANDARD</StorageClass>
+            <Owner>
+                <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                <DisplayName>mtd@amazon.com</DisplayName>
+            </Owner>
+        </Version>
+        <Version>
+            <Key>my-image.jpg</Key>
+            <VersionId>QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</VersionId>
+            <IsLatest>false</IsLatest>
+            <LastModified>2009-10-10T17:50:30.000Z</LastModified>
+            <ETag>&quot;9b2cf535f27731c974343645a3985328&quot;</ETag>
+            <Size>166434</Size>
+            <StorageClass>STANDARD</StorageClass>
+            <Owner>
+                <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                <DisplayName>mtd@amazon.com</DisplayName>
+            </Owner>
+        </Version>
+        <Version>
+            <Key>my-image.jpg</Key>
+            <VersionId>UIORUnfndfhnw89493jJFJ</VersionId>
+            <IsLatest>false</IsLatest>
+            <LastModified>2009-10-11T12:50:30.000Z</LastModified>
+            <ETag>&quot;772cf535f27731c974343645a3985328&quot;</ETag>
+            <Size>64</Size>
+            <StorageClass>STANDARD</StorageClass>
+            <Owner>
+                <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                <DisplayName>mtd@amazon.com</DisplayName>
+            </Owner>
+        </Version>
+    </ListVersionsResult>'''
+
+
+@pytest.fixture
+def folder_and_contents(base_prefix):
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <Marker/>
+            <MaxKeys>1000</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+            <Contents>
+                <Key>{prefix}thisfolder/</Key>
+                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                <Size>0</Size>
+                <StorageClass>STANDARD</StorageClass>
+                <Owner>
+                    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                    <DisplayName>mtd@amazon.com</DisplayName>
+                </Owner>
+            </Contents>
+            <Contents>
+                <Key>{prefix}thisfolder/item1</Key>
+                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                <Size>0</Size>
+                <StorageClass>STANDARD</StorageClass>
+                <Owner>
+                    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                    <DisplayName>mtd@amazon.com</DisplayName>
+                </Owner>
+            </Contents>
+            <Contents>
+                <Key>{prefix}thisfolder/item2</Key>
+                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                <Size>0</Size>
+                <StorageClass>STANDARD</StorageClass>
+                <Owner>
+                    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                    <DisplayName>mtd@amazon.com</DisplayName>
+                </Owner>
+            </Contents>
+        </ListBucketResult>'''.format(prefix=base_prefix)
+
+
+@pytest.fixture
+def folder_empty_metadata():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <Marker/>
+            <MaxKeys>1000</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+        </ListBucketResult>'''
+
+
+@pytest.fixture
+def folder_item_metadata(base_prefix):
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <Marker/>
+            <MaxKeys>1000</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+            <Contents>
+                <Key>{prefix}naptime/</Key>
+                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                <Size>0</Size>
+                <StorageClass>STANDARD</StorageClass>
+                <Owner>
+                    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                    <DisplayName>mtd@amazon.com</DisplayName>
+                </Owner>
+            </Contents>
+        </ListBucketResult>'''.format(prefix=base_prefix)
+
+
+@pytest.fixture
+def folder_metadata(base_prefix):
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <Marker/>
+            <MaxKeys>1000</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+            <Contents>
+                <Key>{prefix}my-image.jpg</Key>
+                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                <Size>434234</Size>
+                <StorageClass>STANDARD</StorageClass>
+                <Owner>
+                    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                    <DisplayName>mtd@amazon.com</DisplayName>
+                </Owner>
+            </Contents>
+            <Contents>
+                <Key>{prefix}my-third-image.jpg</Key>
+                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                <ETag>&quot;1b2cf535f27731c974343645a3985328&quot;</ETag>
+                <Size>64994</Size>
+                <StorageClass>STANDARD</StorageClass>
+                <Owner>
+                    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                    <DisplayName>mtd@amazon.com</DisplayName>
+                </Owner>
+            </Contents>
+            <CommonPrefixes>
+                <Prefix>{prefix}   photos/</Prefix>
+            </CommonPrefixes>
+        </ListBucketResult>'''.format(prefix=base_prefix)
+
+
+@pytest.fixture
+def folder_single_item_metadata(base_prefix):
+    return'''<?xml version="1.0" encoding="UTF-8"?>
+    <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Name>bucket</Name>
+        <Prefix/>
+        <Marker/>
+        <MaxKeys>1000</MaxKeys>
+        <IsTruncated>false</IsTruncated>
+        <Contents>
+            <Key>{prefix}my-image.jpg</Key>
+            <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+            <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+            <Size>434234</Size>
+            <StorageClass>STANDARD</StorageClass>
+            <Owner>
+                <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                <DisplayName>mtd@amazon.com</DisplayName>
+            </Owner>
+        </Contents>
+        <CommonPrefixes>
+            <Prefix>{prefix}   photos/</Prefix>
+        </CommonPrefixes>
+    </ListBucketResult>'''.format(prefix=base_prefix)
+
+
+@pytest.fixture
+def complete_upload_resp():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Location>http://Example-Bucket.s3.amazonaws.com/Example-Object</Location>
+        <Bucket>Example-Bucket</Bucket>
+        <Key>Example-Object</Key>
+        <ETag>"3858f62230ac3c915f300c664312c11f-9"</ETag>
+    </CompleteMultipartUploadResult>'''
+
+
+@pytest.fixture
+def create_session_resp():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+       <Bucket>example-bucket</Bucket>
+       <Key>example-object</Key>
+       <UploadId>EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-</UploadId>
+    </InitiateMultipartUploadResult>'''
+
+
+@pytest.fixture
+def generic_http_403_resp():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <Error>
+        <Code>AccessDenied</Code>
+        <Message>Access Denied</Message>
+        <RequestId>656c76696e6727732072657175657374</RequestId>
+        <HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>
+    </Error>'''
+
+
+@pytest.fixture
+def generic_http_404_resp():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <Error>
+        <Code>NotFound</Code>
+        <Message>Not Found</Message>
+        <RequestId>656c76696e6727732072657175657374</RequestId>
+        <HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>
+    </Error>'''
+
+
+@pytest.fixture
+def list_parts_resp_empty():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Bucket>example-bucket</Bucket>
+        <Key>example-object</Key>
+        <UploadId>XXBsb2FkIElEIGZvciBlbHZpbmcncyVcdS1tb3ZpZS5tMnRzEEEwbG9hZA</UploadId>
+        <Initiator>
+            <ID>arn:aws:iam::111122223333:user/some-user-11116a31-17b5-4fb7-9df5-b288870f11xx</ID>
+            <DisplayName>umat-user-11116a31-17b5-4fb7-9df5-b288870f11xx</DisplayName>
+        </Initiator>
+        <Owner>
+            <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+            <DisplayName>someName</DisplayName>
+        </Owner>
+        <StorageClass>STANDARD</StorageClass>
+    </ListPartsResult>'''
+
+
+@pytest.fixture
+def list_parts_resp_not_empty():
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Bucket>example-bucket</Bucket>
+        <Key>example-object</Key>
+        <UploadId>XXBsb2FkIElEIGZvciBlbHZpbmcncyVcdS1tb3ZpZS5tMnRzEEEwbG9hZA</UploadId>
+        <Initiator>
+            <ID>arn:aws:iam::111122223333:user/some-user-11116a31-17b5-4fb7-9df5-b288870f11xx</ID>
+            <DisplayName>umat-user-11116a31-17b5-4fb7-9df5-b288870f11xx</DisplayName>
+        </Initiator>
+        <Owner>
+            <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+            <DisplayName>someName</DisplayName>
+        </Owner>
+        <StorageClass>STANDARD</StorageClass>
+        <PartNumberMarker>1</PartNumberMarker>
+        <NextPartNumberMarker>3</NextPartNumberMarker>
+        <MaxParts>2</MaxParts>
+        <IsTruncated>true</IsTruncated>
+        <Part>
+            <PartNumber>2</PartNumber>
+            <LastModified>2010-11-10T20:48:34.000Z</LastModified>
+            <ETag>"7778aef83f66abc1fa1e8477f296d394"</ETag>
+            <Size>10485760</Size>
+        </Part>
+        <Part>
+            <PartNumber>3</PartNumber>
+            <LastModified>2010-11-10T20:48:33.000Z</LastModified>
+            <ETag>"aaaa18db4cc2f85cedef654fccc4a4x8"</ETag>
+            <Size>10485760</Size>
+        </Part>
+    </ListPartsResult>'''
+
+
+@pytest.fixture
+def upload_parts_headers_list():
+    return '''{
+        "headers_list": [
+            {
+                "x-amz-id-2": "Vvag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==",
+                "x-amz-request-id": "656c76696e6727732072657175657374",
+                "Date": "Mon, 1 Nov 2010 20:34:54 GMT",
+                "ETag": "b54357faf0632cce46e942fa68356b38",
+                "Content-Length": "0",
+                "Connection": "keep-alive",
+                "Server": "AmazonS3"
+            },
+            {
+                "x-amz-id-2": "imru9pO4ZVKnJ2Qz7Vvag1LuByRx9e6j5On/CAtRPfTaOFg1NPcfTW==",
+                "x-amz-request-id": "732072657175657374656c76696e75657374",
+                "Date": "Mon, 1 Nov 2010 20:35:55 GMT",
+                "ETag": "46e942fa68356b38b54357faf0632cce",
+                "Content-Length": "0",
+                "Connection": "keep-alive",
+                "Server": "AmazonS3"
+            },
+            {
+                "x-amz-id-2": "yRx9e6j5Onimru9pOVvag1LuB4ZVKnJ2Qz7/cfTWAtRPf1NPTaOFg==",
+                "x-amz-request-id": "67277320726571656c76696e75657374",
+                "Date": "Mon, 1 Nov 2010 20:36:56 GMT",
+                "ETag": "af0632cce46e942fab54357f68356b38",
+                "Content-Length": "0",
+                "Connection": "keep-alive",
+                "Server": "AmazonS3"
+            }
+        ]
+    }'''
+
+
+def location_response(location):
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+    <LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">{location}</LocationConstraint>
+    '''.format(location=location)
+
+
+def list_objects_response(keys, truncated=False):
+    response = '''<?xml version="1.0" encoding="UTF-8"?>
+    <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Name>bucket</Name>
+        <Prefix/>
+        <Marker/>
+        <MaxKeys>1000</MaxKeys>'''
+
+    response += '<IsTruncated>' + str(truncated).lower() + '</IsTruncated>'
+    response += ''.join(map(
+        lambda x: '<Contents><Key>{}</Key></Contents>'.format(x),
+        keys
+    ))
+
+    response += '</ListBucketResult>'
+
+    return response.encode('utf-8')
+
+
+def bulk_delete_body(keys):
+    payload = '<?xml version="1.0" encoding="UTF-8"?>'
+    payload += '<Delete>'
+    payload += ''.join(map(
+        lambda x: '<Object><Key>{}</Key></Object>'.format(x),
+        keys
+    ))
+    payload += '</Delete>'
+    payload = payload.encode('utf-8')
+
+    md5 = base64.b64encode(hashlib.md5(payload).digest())
+    headers = {
+        'Content-Length': str(len(payload)),
+        'Content-MD5': md5.decode('ascii'),
+        'Content-Type': 'text/xml',
+    }
+
+    return (payload, headers)
+
+
+def build_folder_params(path):
+    prefix = path.full_path.lstrip('/')
+    return {'prefix': prefix, 'delimiter': '/'}
+
+
+def build_folder_params_with_max_key(path):
+    return {'prefix': path.path, 'delimiter': '/', 'max-keys': '1000'}
+
+
+def list_upload_chunks_body(parts_metadata):
+    payload = '''<?xml version="1.0" encoding="UTF-8"?>
+        <ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Bucket>example-bucket</Bucket>
+            <Key>example-object</Key>
+            <UploadId>XXBsb2FkIElEIGZvciBlbHZpbmcncyVcdS1tb3ZpZS5tMnRzEEEwbG9hZA</UploadId>
+            <Initiator>
+                <ID>arn:aws:iam::111122223333:user/some-user-11116a31-17b5-4fb7-9df5-b288870f11xx</ID>
+                <DisplayName>umat-user-11116a31-17b5-4fb7-9df5-b288870f11xx</DisplayName>
+            </Initiator>
+            <Owner>
+                <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                <DisplayName>someName</DisplayName>
+            </Owner>
+            <StorageClass>STANDARD</StorageClass>
+            <PartNumberMarker>1</PartNumberMarker>
+            <NextPartNumberMarker>3</NextPartNumberMarker>
+            <MaxParts>2</MaxParts>
+            <IsTruncated>false</IsTruncated>
+            <Part>
+                <PartNumber>2</PartNumber>
+                <LastModified>2010-11-10T20:48:34.000Z</LastModified>
+                <ETag>"7778aef83f66abc1fa1e8477f296d394"</ETag>
+                <Size>10485760</Size>
+            </Part>
+            <Part>
+                <PartNumber>3</PartNumber>
+                <LastModified>2010-11-10T20:48:33.000Z</LastModified>
+                <ETag>"aaaa18db4cc2f85cedef654fccc4a4x8"</ETag>
+                <Size>10485760</Size>
+            </Part>
+        </ListPartsResult>
+    '''.encode('utf-8')
+
+    md5 = compute_md5(BytesIO(payload))
+
+    headers = {
+        'Content-Length': str(len(payload)),
+        'Content-MD5': md5[1],
+        'Content-Type': 'text/xml',
+    }
+
+    return payload, headers
+
+
+def prepare_xml_body(object_dict):
+    payload = '<?xml version="1.0" encoding="UTF-8"?>'
+    payload += '<Delete>'
+    payload += ''.join(
+        '<Object><Key>{}</Key><VersionId>{}</VersionId></Object>'.format(
+            xml.sax.saxutils.escape(key), xml.sax.saxutils.escape(version)
+        )
+        for key, value in object_dict.items()
+        for version in value
+    )
+    payload += '</Delete>'
+    payload = payload.encode('utf-8')
+    return payload
+
+
+class TestProviderConstruction:
+
+    def test_https(self, auth, credentials, settings):
+        provider = S3CompatSigV4Provider(auth, {'host': 'securehost',
+                                           'access_key': 'a',
+                                           'secret_key': 's'}, settings)
+        assert provider.connection.use_ssl
+        assert provider.connection.verify_ssl
+        assert provider.connection.endpoint_url == 'https://securehost'
+
+        provider = S3CompatSigV4Provider(auth, {'host': 'securehost:443',
+                                           'access_key': 'a',
+                                           'secret_key': 's'}, settings)
+        assert provider.connection.use_ssl
+        assert provider.connection.verify_ssl
+        assert provider.connection.endpoint_url == 'https://securehost'
+
+    def test_http(self, auth, credentials, settings):
+        provider = S3CompatSigV4Provider(auth, {'host': 'normalhost:80',
+                                           'access_key': 'a',
+                                           'secret_key': 's'}, settings)
+        assert not provider.connection.use_ssl
+        assert provider.connection.endpoint_url == 'http://normalhost'
+
+        provider = S3CompatSigV4Provider(auth, {'host': 'normalhost:8080',
+                                           'access_key': 'a',
+                                           'secret_key': 's'}, settings)
+        assert not provider.connection.use_ssl
+        assert provider.connection.endpoint_url == 'http://normalhost:8080'
+
+
+class TestValidatePath:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_validate_v1_path_file(self, provider, file_header_metadata, mock_time, generate_url_helper):
+        file_path = 'foobah'
+        full_path = file_path
+        prefix = provider.prefix
+        if prefix:
+            full_path = prefix + full_path
+        params_for_dir = {'Prefix': full_path + '/', 'Delimiter': '/'}
+        good_metadata_url = generate_url_helper(key=full_path, method='HEAD', expires=100)
+        bad_metadata_url = generate_url_helper(method='GET', expires=100, query_parameters=params_for_dir)
+        aiohttpretty.register_uri('HEAD', good_metadata_url, headers=file_header_metadata)
+        aiohttpretty.register_uri('GET', bad_metadata_url, status=404)
+
+        assert WaterButlerPath('/') == await provider.validate_v1_path('/')
+
+        try:
+            wb_path_v1 = await provider.validate_v1_path('/' + file_path)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            await provider.validate_v1_path('/' + file_path + '/')
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = await provider.validate_path('/' + file_path)
+
+        assert wb_path_v1 == wb_path_v0
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_validate_v1_path_folder(self, provider, folder_metadata, mock_time, generate_url_helper):
+        folder_path = 'Photos'
+        full_path = folder_path
+        prefix = provider.prefix
+        if prefix:
+            full_path = prefix + full_path
+
+        params_for_dir = {'Prefix': full_path + '/', 'Delimiter': '/'}
+        good_metadata_url = generate_url_helper(method='GET', expires=100, query_parameters=params_for_dir)
+        bad_metadata_url = generate_url_helper(key=full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri(
+            'GET', good_metadata_url,
+            body=folder_metadata, headers={'Content-Type': 'application/xml'}
+        )
+        aiohttpretty.register_uri('HEAD', bad_metadata_url, status=404)
+
+        try:
+            wb_path_v1 = await provider.validate_v1_path('/' + folder_path + '/')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            await provider.validate_v1_path('/' + folder_path)
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = await provider.validate_path('/' + folder_path + '/')
+
+        assert wb_path_v1 == wb_path_v0
+
+    @pytest.mark.asyncio
+    async def test_normal_name(self, provider, mock_time):
+        path = await provider.validate_path('/this/is/a/path.txt')
+        assert path.name == 'path.txt'
+        assert path.parent.name == 'a'
+        assert path.is_file
+        assert not path.is_dir
+        assert not path.is_root
+
+    @pytest.mark.asyncio
+    async def test_folder(self, provider, mock_time):
+        path = await provider.validate_path('/this/is/a/folder/')
+        assert path.name == 'folder'
+        assert path.parent.name == 'a'
+        assert not path.is_file
+        assert path.is_dir
+        assert not path.is_root
+
+    @pytest.mark.asyncio
+    async def test_root(self, provider, mock_time):
+        path = await provider.validate_path('/this/is/a/folder/')
+        assert path.name == 'folder'
+        assert path.parent.name == 'a'
+        assert not path.is_file
+        assert path.is_dir
+        assert not path.is_root
+
+
+class TestCRUD:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download(self, provider, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/muhtriangle', prepend=provider.prefix)
+
+        head_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri('HEAD', head_url, headers=file_header_metadata)
+
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+        get_url = generate_url_helper(key=path.full_path, method='GET', expires=100, response_headers=response_headers)
+
+        aiohttpretty.register_uri('GET', get_url,
+                              body=b'delicious',
+                              headers=file_header_metadata,
+                              auto_length=True)
+
+        result = await provider.download(path)
+        content = await result.read()
+
+        assert content == b'delicious'
+        assert result._size == 9
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_range(self, provider, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/muhtriangle', prepend=provider.prefix)
+
+        head_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri('HEAD', head_url, headers=file_header_metadata)
+
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+        get_url = generate_url_helper(key=path.full_path, method='GET', expires=100, response_headers=response_headers)
+        aiohttpretty.register_uri('GET', get_url,
+                                  body=b'de', auto_length=True, status=206)
+
+        result = await provider.download(path, range=(0, 1))
+        assert result.partial
+        content = await result.read()
+        content_size = result._size
+        assert content == b'de'
+        assert content_size == 2
+        assert aiohttpretty.has_call(method='GET', uri=get_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_version(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/muhtriangle', prepend=provider.prefix)
+        versionid_parameter = {'VersionId': 'someversion'}
+
+        head_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100, query_parameters=versionid_parameter)
+        aiohttpretty.register_uri('HEAD', head_url, headers={'Content-Length': '9'})
+
+        get_url = generate_url_helper(key=path.full_path, method='GET', expires=100, query_parameters=versionid_parameter, response_headers={'response-content-disposition': 'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'})
+        aiohttpretty.register_uri('GET', get_url,
+                                  body=b'delicious', auto_length=True)
+
+        result = await provider.download(path, revision='someversion')
+        content = await result.read()
+
+        assert content == b'delicious'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    @pytest.mark.parametrize("display_name_arg,expected_name", [
+        ('meow.txt', 'meow.txt'),
+        ('',         'muhtriangle'),
+        (None,       'muhtriangle'),
+    ])
+    async def test_download_with_display_name(self, provider, mock_time, generate_url_helper, display_name_arg, expected_name):
+        path = WaterButlerPath('/muhtriangle', prepend=provider.prefix)
+
+        head_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri('HEAD', head_url, headers={'Content-Length': '9'})
+
+        response_headers = {
+            'response-content-disposition': ('attachment; filename="{}"; '
+                                             'filename*=UTF-8\'\'{}').format(expected_name,
+                                                                             expected_name)
+        }
+        get_url = generate_url_helper(key=path.full_path, method='GET', expires=100, response_headers=response_headers)
+        aiohttpretty.register_uri('GET', get_url,
+                                  body=b'delicious', auto_length=True)
+
+        result = await provider.download(path, display_name=display_name_arg)
+        content = await result.read()
+
+        assert content == b'delicious'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_not_found(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/muhtriangle', prepend=provider.prefix)
+
+        head_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri('HEAD', head_url, status=404)
+
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+        url = generate_url_helper(key=path.full_path, method='GET', expires=100, response_headers=response_headers)
+        aiohttpretty.register_uri('GET', url, status=404)
+
+        with pytest.raises(exceptions.DownloadError):
+            await provider.download(path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_no_content_length(self, provider, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/muhtriangle', prepend=provider.prefix)
+
+        head_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri('HEAD', head_url, headers=file_header_metadata)
+
+        # aiohttpretty.register_uri uses shallow copy for headers.
+        # Therefore, we need to use a deep copied dictionary for GET.
+        no_content_length_metadata = file_header_metadata.copy()
+        del no_content_length_metadata['Content-Length']
+
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+        get_url = generate_url_helper(key=path.full_path, method='GET', expires=100, response_headers=response_headers)
+        aiohttpretty.register_uri('GET', get_url,
+                                  body=b'delicious', headers=no_content_length_metadata)
+
+        result = await provider.download(path)
+        content = await result.read()
+
+        assert content == b'delicious'
+        assert result._size == int(file_header_metadata['Content-Length'])
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_content_replaced(self, provider, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/muhtriangle', prepend=provider.prefix)
+
+        head_header_metadata = file_header_metadata.copy()
+        file_header_metadata['ETag'] = '"1accb31fcf202eba0c0f41fa2f09b4d7"'
+        file_header_metadata['Content-Length'] = 300
+        head_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri('HEAD', head_url, headers=head_header_metadata)
+
+        response_headers = {'response-content-disposition':
+                            'attachment; filename="muhtriangle"; filename*=UTF-8\'\'muhtriangle'}
+        get_url = generate_url_helper(key=path.full_path, method='GET', expires=100, response_headers=response_headers)
+        aiohttpretty.register_uri('GET', get_url,
+                                  body=b'delicious', headers=file_header_metadata, auto_length=True)
+
+        result = await provider.download(path)
+        content = await result.read()
+
+        assert content == b'delicious'
+        assert result._size == 9
+        assert aiohttpretty.has_call(method='HEAD', uri=head_url)
+        assert aiohttpretty.has_call(method='GET', uri=get_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_folder_400s(self, provider, mock_time):
+        with pytest.raises(exceptions.DownloadError) as e:
+            await provider.download(WaterButlerPath('/cool/folder/mom/', prepend=provider.prefix))
+        assert e.value.code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload_update(self, provider, file_content, file_stream, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        content_md5 = hashlib.md5(file_content).hexdigest()
+        url = generate_url_helper(key=path.full_path, method='PUT', expires=100)
+        metadata_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri('HEAD', metadata_url, headers=file_header_metadata)
+        header = {'ETag': '"{}"'.format(content_md5)}
+        aiohttpretty.register_uri('PUT', url, status=201, headers=header)
+
+        metadata, created = await provider.upload(file_stream, path)
+
+        assert metadata.kind == 'file'
+        assert not created
+        assert aiohttpretty.has_call(method='PUT', uri=url)
+        assert aiohttpretty.has_call(method='HEAD', uri=metadata_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload_encrypted(self, provider, file_content, file_stream, file_header_metadata, mock_time, generate_url_helper):
+        # Set trigger for encrypt_key=True in s3compatsigv4.provider.upload
+        provider.encrypt_uploads = True
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        content_md5 = hashlib.md5(file_content).hexdigest()
+        url = generate_url_helper(key=path.full_path, method='PUT', expires=100, encrypt_key=True)
+        metadata_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100)
+        aiohttpretty.register_uri(
+            'HEAD',
+            metadata_url,
+            responses=[
+                {'status': 404},
+                {'headers': file_header_metadata},
+            ],
+        )
+        headers = {'ETag': '"{}"'.format(content_md5)}
+        aiohttpretty.register_uri('PUT', url, status=200, headers=headers)
+
+        metadata, created = await provider.upload(file_stream, path)
+
+        assert metadata.kind == 'file'
+        assert metadata.extra['encryption'] == 'AES256'
+        assert created
+        assert aiohttpretty.has_call(method='PUT', uri=url)
+        assert aiohttpretty.has_call(method='HEAD', uri=metadata_url)
+
+        # Fixtures are shared between tests. Need to revert the settings back.
+        provider.encrypt_uploads = False
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_limit_chunked(self, provider, file_stream, mock_time):
+        assert file_stream.size == 6
+        provider.CONTIGUOUS_UPLOAD_SIZE_LIMIT = 5
+        provider.CHUNK_SIZE = 2
+
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        provider._chunked_upload = MockCoroutine()
+        provider.metadata = MockCoroutine()
+
+        await provider.upload(file_stream, path)
+
+        provider._chunked_upload.assert_called_with(file_stream, path)
+
+        # Fixtures are shared between tests. Need to revert the settings back.
+        provider.CONTIGUOUS_UPLOAD_SIZE_LIMIT = pd_settings.CONTIGUOUS_UPLOAD_SIZE_LIMIT
+        provider.CHUNK_SIZE = pd_settings.CHUNK_SIZE
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_complete(self, provider, upload_parts_headers_list, file_stream, mock_time):
+        assert file_stream.size == 6
+        provider.CONTIGUOUS_UPLOAD_SIZE_LIMIT = 5
+        provider.CHUNK_SIZE = 2
+
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        headers_list = json.loads(upload_parts_headers_list).get('headers_list')
+        headers_list = [{k.upper(): v for k, v in headers.items()} for headers in headers_list]
+
+        provider.metadata = MockCoroutine()
+        provider._create_upload_session = MockCoroutine()
+        provider._create_upload_session.return_value = upload_id
+        provider._upload_parts = MockCoroutine()
+        provider._upload_parts.return_value = headers_list
+        provider._complete_multipart_upload = MockCoroutine()
+
+        await provider._chunked_upload(file_stream, path)
+
+        provider._create_upload_session.assert_called_with(path)
+        provider._upload_parts.assert_called_with(file_stream, path, upload_id)
+        provider._complete_multipart_upload.assert_called_with(path, upload_id, headers_list)
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_aborted_success(self, provider, upload_parts_headers_list, file_stream, mock_time):
+        assert file_stream.size == 6
+        provider.CONTIGUOUS_UPLOAD_SIZE_LIMIT = 5
+        provider.CHUNK_SIZE = 2
+
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        headers_list = json.loads(upload_parts_headers_list).get('headers_list')
+        headers_list = [{k.upper(): v for k, v in headers.items()} for headers in headers_list]
+
+        provider.metadata = MockCoroutine()
+        provider._create_upload_session = MockCoroutine()
+        provider._create_upload_session.return_value = upload_id
+        provider._upload_parts = MockCoroutine()
+        provider._upload_parts.return_value = headers_list
+        provider._upload_part = MockCoroutine()
+        provider._upload_part.side_effect = Exception('error')
+        provider._abort_chunked_upload = MockCoroutine()
+        provider._abort_chunked_upload.return_value = True
+
+        with pytest.raises(exceptions.UploadError) as exc:
+            await provider._chunked_upload(file_stream, path)
+        msg = 'An unexpected error has occurred during the multi-part upload.'
+        msg += '  The abort action failed to clean up the temporary file parts generated ' \
+               'during the upload process.  Please manually remove them.'
+        assert str(exc.value) == ', '.join(['500', msg])
+
+        provider._create_upload_session.assert_called_with(path)
+        provider._upload_parts.assert_called_with(file_stream, path, upload_id)
+        provider._abort_chunked_upload.assert_called_with(path, upload_id)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_limit_contiguous(self, provider, file_stream, mock_time):
+        assert file_stream.size == 6
+        provider.CONTIGUOUS_UPLOAD_SIZE_LIMIT = 10
+        provider.CHUNK_SIZE = 2
+
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        provider._contiguous_upload = MockCoroutine()
+        provider.metadata = MockCoroutine()
+
+        await provider.upload(file_stream, path)
+
+        provider._contiguous_upload.assert_called_with(file_stream, path)
+
+        provider.CONTIGUOUS_UPLOAD_SIZE_LIMIT = pd_settings.CONTIGUOUS_UPLOAD_SIZE_LIMIT
+        provider.CHUNK_SIZE = pd_settings.CHUNK_SIZE
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_create_upload_session_no_encryption(self, provider, create_session_resp, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        init_url = generate_url_helper(key=path.full_path, method='POST', expires=200, query_parameters={'uploads': ''})
+
+        aiohttpretty.register_uri('POST', init_url, body=create_session_resp, status=200)
+
+        session_id = await provider._create_upload_session(path)
+        expected_session_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                              '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+
+        assert aiohttpretty.has_call(method='POST', uri=init_url)
+        assert session_id is not None
+        assert session_id == expected_session_id
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_create_upload_session_with_encryption(self, provider,
+                                                                        create_session_resp,
+                                                                        mock_time, generate_url_helper):
+        provider.encrypt_uploads = True
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        init_url = generate_url_helper(key=path.full_path, method='POST', expires=200, query_parameters={'uploads': ''}, encrypt_key=True)
+
+        aiohttpretty.register_uri('POST', init_url, body=create_session_resp, status=200)
+
+        session_id = await provider._create_upload_session(path)
+        expected_session_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                              '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+
+        assert aiohttpretty.has_call(method='POST', uri=init_url)
+        assert session_id is not None
+        assert session_id == expected_session_id
+
+        provider.encrypt_uploads = False
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_create_upload_session_with_full_path(self, provider,
+                                                                        create_session_resp,
+                                                                        mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix + 'project_folder/')
+        init_url_full_path = generate_url_helper(key=path.full_path, method='POST', expires=200, query_parameters={'uploads': ''})
+        init_url_path = generate_url_helper(key=path.path, method='POST', expires=200, query_parameters={'uploads': ''})
+
+        aiohttpretty.register_uri('POST', init_url_full_path, body=create_session_resp, status=200)
+        aiohttpretty.register_uri('POST', init_url_path, body=create_session_resp, status=200)
+
+        session_id = await provider._create_upload_session(path)
+
+        assert aiohttpretty.has_call(method='POST', uri=init_url_full_path)
+        assert aiohttpretty.has_call(method='POST', uri=init_url_path) is False
+        assert session_id is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_upload_parts(self, provider, file_stream,
+                                               upload_parts_headers_list):
+        assert file_stream.size == 6
+        provider.CHUNK_SIZE = 2
+
+        side_effect = json.loads(upload_parts_headers_list).get('headers_list')
+        assert len(side_effect) == 3
+
+        provider._upload_part = MockCoroutine(side_effect=side_effect)
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+
+        parts_metadata = await provider._upload_parts(file_stream, path, upload_id)
+
+        assert provider._upload_part.call_count == 3
+        assert len(parts_metadata) == 3
+        assert parts_metadata == side_effect
+
+        provider.CHUNK_SIZE = pd_settings.CHUNK_SIZE
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_upload_parts_remainder(self, provider,
+                                                         upload_parts_headers_list):
+
+        file_stream = streams.StringStream('abcdefghijklmnopqrst')
+        assert file_stream.size == 20
+        provider.CHUNK_SIZE = 9
+
+        side_effect = json.loads(upload_parts_headers_list).get('headers_list')
+        assert len(side_effect) == 3
+
+        provider._upload_part = MockCoroutine(side_effect=side_effect)
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+
+        parts_metadata = await provider._upload_parts(file_stream, path, upload_id)
+
+        assert provider._upload_part.call_count == 3
+        provider._upload_part.assert_has_calls([
+            mock.call(file_stream, path, upload_id, 1, 9),
+            mock.call(file_stream, path, upload_id, 2, 9),
+            mock.call(file_stream, path, upload_id, 3, 2),
+        ])
+        assert len(parts_metadata) == 3
+        assert parts_metadata == side_effect
+
+        provider.CHUNK_SIZE = pd_settings.CHUNK_SIZE
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_upload_part(self, provider, file_stream,
+                                              upload_parts_headers_list,
+                                              mock_time, generate_url_helper):
+        assert file_stream.size == 6
+        provider.CHUNK_SIZE = 2
+
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        chunk_number = 1
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {
+            'partNumber': str(chunk_number),
+            'uploadId': upload_id,
+        }
+        headers = {'Content-Length': str(provider.CHUNK_SIZE)}
+        upload_part_url = generate_url_helper(key=path.full_path, method='PUT', expires=200, query_parameters=params, headers=headers)
+        # aiohttp resp headers use upper case
+        part_headers = json.loads(upload_parts_headers_list).get('headers_list')[0]
+        part_headers = {k.upper(): v for k, v in part_headers.items()}
+        aiohttpretty.register_uri('PUT', upload_part_url, status=200, headers=part_headers)
+
+        part_metadata = await provider._upload_part(file_stream, path, upload_id, chunk_number,
+                                                    provider.CHUNK_SIZE)
+
+        assert aiohttpretty.has_call(method='PUT', uri=upload_part_url)
+        assert part_headers == part_metadata
+
+        provider.CHUNK_SIZE = pd_settings.CHUNK_SIZE
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_upload_part_with_full_path(self, provider, file_stream,
+                                              upload_parts_headers_list,
+                                              mock_time, generate_url_helper):
+        assert file_stream.size == 6
+        provider.CHUNK_SIZE = 2
+
+        path = WaterButlerPath('/foobah', prepend=provider.prefix + 'project_folder/')
+        chunk_number = 1
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u'
+        params = {
+            'partNumber': str(chunk_number),
+            'uploadId': upload_id,
+        }
+        headers = {'Content-Length': str(provider.CHUNK_SIZE)}
+        upload_part_url_full_path = generate_url_helper(key=path.full_path, method='PUT', expires=200, query_parameters=params, headers=headers)
+        upload_part_url_path = generate_url_helper(key=path.path, method='PUT', expires=200, query_parameters=params, headers=headers)
+        # aiohttp resp headers use upper case
+        part_headers = json.loads(upload_parts_headers_list).get('headers_list')[0]
+        part_headers = {k.upper(): v for k, v in part_headers.items()}
+
+        aiohttpretty.register_uri('PUT', upload_part_url_path, status=200, headers=part_headers)
+        aiohttpretty.register_uri('PUT', upload_part_url_full_path, status=200, headers=part_headers)
+
+        part_metadata = await provider._upload_part(file_stream, path, upload_id, chunk_number,
+                                                    provider.CHUNK_SIZE)
+
+        assert aiohttpretty.has_call(method='PUT', uri=upload_part_url_full_path)
+        assert aiohttpretty.has_call(method='PUT', uri=upload_part_url_path) is False
+        assert part_headers == part_metadata
+
+        provider.CHUNK_SIZE = pd_settings.CHUNK_SIZE
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_complete_multipart_upload(self, provider,
+                                                            upload_parts_headers_list,
+                                                            complete_upload_resp, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        payload = '<?xml version="1.0" encoding="UTF-8"?>'
+        payload += '<CompleteMultipartUpload>'
+        # aiohttp resp headers are upper case
+        headers_list = json.loads(upload_parts_headers_list).get('headers_list')
+        headers_list = [{k.upper(): v for k, v in headers.items()} for headers in headers_list]
+        for i, part in enumerate(headers_list):
+            payload += '<Part>'
+            payload += '<PartNumber>{}</PartNumber>'.format(i+1)  # part number must be >= 1
+            payload += '<ETag>{}</ETag>'.format(xml.sax.saxutils.escape(part['ETAG']))
+            payload += '</Part>'
+        payload += '</CompleteMultipartUpload>'
+        payload = payload.encode('utf-8')
+
+        headers = {
+            'Content-Length': str(len(payload)),
+            'Content-MD5': compute_md5(BytesIO(payload))[1],
+            'Content-Type': 'text/xml',
+        }
+
+        complete_url = generate_url_helper(key=path.full_path, method='POST', expires=200, headers=headers, query_parameters=params)
+
+        aiohttpretty.register_uri(
+            'POST',
+            complete_url,
+            status=200,
+            body=complete_upload_resp
+        )
+
+        await provider._complete_multipart_upload(path, upload_id, headers_list)
+
+        assert aiohttpretty.has_call(method='POST', uri=complete_url, params=params)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_complete_multipart_upload_with_full_path(self, provider,
+                                                            upload_parts_headers_list,
+                                                            complete_upload_resp, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix + 'project_folder/')
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        payload = '<?xml version="1.0" encoding="UTF-8"?>'
+        payload += '<CompleteMultipartUpload>'
+        # aiohttp resp headers are upper case
+        headers_list = json.loads(upload_parts_headers_list).get('headers_list')
+        headers_list = [{k.upper(): v for k, v in headers.items()} for headers in headers_list]
+        for i, part in enumerate(headers_list):
+            payload += '<Part>'
+            payload += '<PartNumber>{}</PartNumber>'.format(i+1)  # part number must be >= 1
+            payload += '<ETag>{}</ETag>'.format(xml.sax.saxutils.escape(part['ETAG']))
+            payload += '</Part>'
+        payload += '</CompleteMultipartUpload>'
+        payload = payload.encode('utf-8')
+
+        headers = {
+            'Content-Length': str(len(payload)),
+            'Content-MD5': compute_md5(BytesIO(payload))[1],
+            'Content-Type': 'text/xml',
+        }
+
+        complete_url_full_path = generate_url_helper(key=path.full_path, method='POST', expires=200, headers=headers, query_parameters=params)
+        complete_url_path = generate_url_helper(key=path.path, method='POST', expires=200, headers=headers, query_parameters=params)
+
+        aiohttpretty.register_uri(
+            'POST',
+            complete_url_full_path,
+            status=200,
+            body=complete_upload_resp
+        )
+        aiohttpretty.register_uri(
+            'POST',
+            complete_url_path,
+            status=200,
+            body=complete_upload_resp
+        )
+
+        await provider._complete_multipart_upload(path, upload_id, headers_list)
+
+        assert aiohttpretty.has_call(method='POST', uri=complete_url_full_path, params=params)
+        assert aiohttpretty.has_call(method='POST', uri=complete_url_path, params=params) is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_chunked_upload_complete_multipart_upload_error(self, provider,
+                                                            upload_parts_headers_list,
+                                                            api_error_resp, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        payload = '<?xml version="1.0" encoding="UTF-8"?>'
+        payload += '<CompleteMultipartUpload>'
+        # aiohttp resp headers are upper case
+        headers_list = json.loads(upload_parts_headers_list).get('headers_list')
+        headers_list = [{k.upper(): v for k, v in headers.items()} for headers in headers_list]
+        for i, part in enumerate(headers_list):
+            payload += '<Part>'
+            payload += '<PartNumber>{}</PartNumber>'.format(i+1)  # part number must be >= 1
+            payload += '<ETag>{}</ETag>'.format(xml.sax.saxutils.escape(part['ETAG']))
+            payload += '</Part>'
+        payload += '</CompleteMultipartUpload>'
+        payload = payload.encode('utf-8')
+
+        headers = {
+            'Content-Length': str(len(payload)),
+            'Content-MD5': compute_md5(BytesIO(payload))[1],
+            'Content-Type': 'text/xml',
+        }
+
+        complete_url = generate_url_helper(key=path.full_path, method='POST', expires=200, headers=headers, query_parameters=params)
+
+        aiohttpretty.register_uri(
+            'POST',
+            complete_url,
+            status=200,
+            body=api_error_resp
+        )
+
+        with pytest.raises(exceptions.UploadError):
+            await provider._complete_multipart_upload(path, upload_id, headers_list)
+
+        assert aiohttpretty.has_call(method='POST', uri=complete_url, params=params)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_abort_chunked_upload_session_deleted(self, provider, generic_http_404_resp,
+                                                        mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        abort_url = generate_url_helper(key=path.full_path, method='DELETE', expires=100, headers={}, query_parameters=params)
+        list_url = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters=params)
+        aiohttpretty.register_uri('DELETE', abort_url, status=204)
+        aiohttpretty.register_uri('GET', list_url, body=generic_http_404_resp, status=404)
+
+        aborted = await provider._abort_chunked_upload(path, upload_id)
+
+        assert aiohttpretty.has_call(method='DELETE', uri=abort_url)
+        assert aborted is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_abort_chunked_upload_list_empty(self, provider, list_parts_resp_empty,
+                                                   mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        abort_url = generate_url_helper(key=path.full_path, method='DELETE', expires=100, headers={}, query_parameters=params)
+        list_url = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters=params)
+        aiohttpretty.register_uri('DELETE', abort_url, status=204)
+        aiohttpretty.register_uri('GET', list_url, body=list_parts_resp_empty, status=200)
+
+        aborted = await provider._abort_chunked_upload(path, upload_id)
+
+        assert aiohttpretty.has_call(method='DELETE', uri=abort_url)
+        assert aiohttpretty.has_call(method='GET', uri=list_url)
+        assert aborted is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_abort_chunked_upload_list_not_empty(self, provider, list_parts_resp_not_empty, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        abort_url = generate_url_helper(key=path.full_path, method='DELETE', expires=100, headers={}, query_parameters=params)
+        list_url = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters=params)
+        aiohttpretty.register_uri('DELETE', abort_url, status=204)
+        aiohttpretty.register_uri('GET', list_url, body=list_parts_resp_not_empty, status=200)
+
+        aborted = await provider._abort_chunked_upload(path, upload_id)
+
+        assert aiohttpretty.has_call(method='DELETE', uri=abort_url)
+        assert aborted is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_abort_chunked_upload_exception(self, provider, upload_parts_headers_list, file_stream, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        abort_url = generate_url_helper(key=path.full_path, method='DELETE', expires=100, headers={}, query_parameters=params)
+        list_url = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters=params)
+        aiohttpretty.register_uri('DELETE', abort_url, status=204)
+        aiohttpretty.register_uri('GET', list_url, body=list_parts_resp_not_empty, status=200)
+        provider._list_uploaded_chunks = MockCoroutine()
+        provider._list_uploaded_chunks.side_effect = Exception('error')
+
+        aborted = await provider._abort_chunked_upload(path, upload_id)
+
+        assert aiohttpretty.has_call(method='DELETE', uri=abort_url)
+        assert aborted is False
+        provider._list_uploaded_chunks.assert_called_with(path, upload_id)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_abort_chunked_upload_with_full_path(self, provider, list_parts_resp_empty,
+                                                   mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix + 'project_folder/')
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        abort_url_full_path = generate_url_helper(key=path.full_path, method='DELETE', expires=100, headers={}, query_parameters=params)
+        abort_url_path = generate_url_helper(key=path.path, method='DELETE', expires=100, headers={}, query_parameters=params)
+        list_url_full_path = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters=params)
+        list_url_path = generate_url_helper(key=path.path, method='GET', expires=100, headers={}, query_parameters=params)
+        aiohttpretty.register_uri('DELETE', abort_url_full_path, status=204)
+        aiohttpretty.register_uri('GET', list_url_full_path, body=list_parts_resp_empty, status=200)
+        aiohttpretty.register_uri('DELETE', abort_url_path, status=204)
+        aiohttpretty.register_uri('GET', list_url_path, body=list_parts_resp_empty, status=200)
+
+        aborted = await provider._abort_chunked_upload(path, upload_id)
+
+        assert aiohttpretty.has_call(method='DELETE', uri=abort_url_full_path)
+        assert aiohttpretty.has_call(method='GET', uri=list_url_full_path)
+        assert aiohttpretty.has_call(method='DELETE', uri=abort_url_path) is False
+        assert aiohttpretty.has_call(method='GET', uri=list_url_path) is False
+        assert aborted is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_list_uploaded_chunks_session_not_found(self,
+                                                          provider,
+                                                          generic_http_404_resp,
+                                                          mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        params = {'uploadId': upload_id}
+        list_url = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters=params)
+        aiohttpretty.register_uri('GET', list_url, body=generic_http_404_resp, status=404)
+
+        resp_xml, session_deleted = await provider._list_uploaded_chunks(path, upload_id)
+
+        assert aiohttpretty.has_call(method='GET', uri=list_url)
+        assert resp_xml is not None
+        assert session_deleted is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_list_uploaded_chunks_empty_list(self,
+                                                   provider,
+                                                   list_parts_resp_empty,
+                                                   mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        list_url = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters={'uploadId': upload_id})
+        aiohttpretty.register_uri('GET', list_url, body=list_parts_resp_empty, status=200)
+
+        resp_xml, session_deleted = await provider._list_uploaded_chunks(path, upload_id)
+
+        assert aiohttpretty.has_call(method='GET', uri=list_url)
+        assert resp_xml is not None
+        assert session_deleted is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_list_uploaded_chunks_list_not_empty(self,
+                                                       provider,
+                                                       list_parts_resp_not_empty,
+                                                       mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        list_url = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters={'uploadId': upload_id})
+        aiohttpretty.register_uri('GET', list_url, body=list_parts_resp_not_empty, status=200)
+
+        resp_xml, session_deleted = await provider._list_uploaded_chunks(path, upload_id)
+
+        assert aiohttpretty.has_call(method='GET', uri=list_url)
+        assert resp_xml is not None
+        assert session_deleted is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_list_uploaded_chunks_with_full_path(self,
+                                                   provider,
+                                                   list_parts_resp_empty,
+                                                   mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix + 'project_folder/')
+        upload_id = 'EXAMPLEJZ6e0YupT2h66iePQCc9IEbYbDUy4RTpMeoSMLPRp8Z5o1u' \
+                    '8feSRonpvnWsKKG35tI2LB9VDPiCgTy.Gq2VxQLYjrue4Nq.NBdqI-'
+        list_url_full_path = generate_url_helper(key=path.full_path, method='GET', expires=100, headers={}, query_parameters={'uploadId': upload_id})
+        list_url_path = generate_url_helper(key=path.path, method='GET', expires=100, headers={}, query_parameters={'uploadId': upload_id})
+        aiohttpretty.register_uri('GET', list_url_full_path, body=list_parts_resp_empty, status=200)
+        aiohttpretty.register_uri('GET', list_url_path, body=list_parts_resp_empty, status=200)
+
+        resp_xml, session_deleted = await provider._list_uploaded_chunks(path, upload_id)
+
+        assert aiohttpretty.has_call(method='GET', uri=list_url_full_path)
+        assert aiohttpretty.has_call(method='GET', uri=list_url_path) is False
+        assert resp_xml is not None
+        assert session_deleted is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/some-file', prepend=provider.prefix)
+
+        # Mock the versions list response - list_object_versions is bucket-level, not object-level
+        # Provider calls with Prefix, Delimiter, VersionIdMarker
+        query_params = {
+            'Prefix': path.path.lstrip('/'),
+            'Delimiter': '/',
+            'VersionIdMarker': ''
+        }
+        versions_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params})
+        params = {
+            'prefix': path.path.lstrip('/'),
+            'delimiter': '/',
+            'version-id-marker': '',
+            'versions': ''
+        }
+        version_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
+                <Name>bucket</Name>
+                <Prefix>some-file</Prefix>
+                <KeyMarker/>
+                <VersionIdMarker/>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                <Version>
+                    <Key>some-file</Key>
+                    <VersionId>null</VersionId>
+                    <IsLatest>true</IsLatest>
+                    <LastModified>2023-01-01T00:00:00.000Z</LastModified>
+                    <ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
+                    <Size>0</Size>
+                    <Owner>
+                        <ID>minio</ID>
+                        <DisplayName>minio</DisplayName>
+                    </Owner>
+                    <StorageClass>STANDARD</StorageClass>
+                </Version>
+            </ListVersionsResult>'''
+        aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_body)
+
+        # Mock the boto3 delete_objects call
+        mock_delete_response = {
+            'Deleted': [{'Key': 'some-file', 'VersionId': 'null'}],
+            'Errors': []
+        }
+        provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
+
+        await provider.delete(path)
+
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
+        # Verify delete_objects was called with correct parameters
+        provider.bucket.delete_objects.assert_called_once()
+        call_args = provider.bucket.delete_objects.call_args
+        assert call_args[1]['Delete']['Objects'] == [{'Key': path.full_path, 'VersionId': 'null'}]
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_confirm_delete(self, provider, version_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/')
+
+        # First call without confirm_delete - file deletion path
+        # Mock request GET versions for file deletion - bucket-level operation
+        query_params_file = {
+            'Prefix': '',
+            'Delimiter': '/',
+            'VersionIdMarker': ''
+        }
+        versions_url_file = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params_file})
+        params_file = {'prefix': '', 'delimiter': '/', 'version-id-marker': '', 'versions': ''}
+        
+        # Second call with confirm_delete=1 - folder deletion path
+        # Mock request GET versions for folder deletion (no Delimiter, no VersionIdMarker)
+        query_params_folder = {'Prefix': ''}
+        versions_url_folder = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params_folder})
+        params_folder = {'prefix': '', 'versions': ''}
+        
+        aiohttpretty.register_uri(
+            'GET',
+            versions_url_file,
+            params=params_file,
+            body=version_metadata,
+            status=200
+        )
+        aiohttpretty.register_uri(
+            'GET',
+            versions_url_folder,
+            params=params_folder,
+            body=version_metadata,
+            status=200
+        )
+
+        # Mock the boto3 delete_objects call
+        mock_delete_response = {
+            'Deleted': [
+                {'Key': 'my-image.jpg', 'VersionId': '3/L4kqtJl40Nr8X8gdRQBpUMLUo'},
+                {'Key': 'my-image.jpg', 'VersionId': 'QUpfdndhfd8438MNFDN93jdnJFkdmqnh893'},
+                {'Key': 'my-image.jpg', 'VersionId': 'UIORUnfndfhnw89493jJFJ'}
+            ],
+            'Errors': []
+        }
+        provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
+
+        with pytest.raises(exceptions.DeleteError):
+            await provider.delete(path)
+
+        await provider.delete(path, confirm_delete=1)
+
+        # Verify delete_objects was called once (for the second call with confirm_delete=1)
+        assert provider.bucket.delete_objects.call_count == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_folder_with_versions(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/folder-to-delete/')
+
+        # Mock list versions response - bucket-level operation
+        query_params = {'Prefix': path.path}
+        versions_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params})
+        params = {'prefix': path.path, 'versions': ''}
+
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <Version>
+                    <Key>folder-to-delete/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+                <Version>
+                    <Key>folder-to-delete/file1.txt</Key>
+                    <VersionId>222</VersionId>
+                </Version>
+                <DeleteMarker>
+                    <Key>folder-to-delete/file2.txt</Key>
+                    <VersionId>333</VersionId>
+                </DeleteMarker>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
+
+        # Mock the boto3 delete_objects call
+        mock_delete_response = {
+            'Deleted': [
+                {'Key': 'folder-to-delete/file1.txt', 'VersionId': '111'},
+                {'Key': 'folder-to-delete/file1.txt', 'VersionId': '222'},
+                {'Key': 'folder-to-delete/file2.txt', 'VersionId': '333'}
+            ],
+            'Errors': []
+        }
+        provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
+
+        await provider._delete_folder(path)
+
+        # Verify list versions request was made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
+
+        # Verify delete_objects was called
+        provider.bucket.delete_objects.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_folder_truncated_response(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/large-folder/')
+
+        # Mock first list versions response (truncated) - bucket-level operation
+        query_params = {'Prefix': path.path}
+        versions_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params})
+        params1 = {'prefix': path.path, 'versions': ''}
+
+        list_versions_body1 = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>true</IsTruncated>
+                <NextKeyMarker>large-folder/file2.txt</NextKeyMarker>
+                <NextVersionIdMarker>222</NextVersionIdMarker>
+                <Version>
+                    <Key>large-folder/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params1, body=list_versions_body1, status=200)
+
+        # Mock second list versions response with pagination markers
+        query_params2 = {
+            'Prefix': path.path,
+            'KeyMarker': 'large-folder/file2.txt',
+            'VersionIdMarker': '222'
+        }
+        versions_url2 = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params2})
+        params2 = {
+            'prefix': path.path,
+            'versions': '',
+            'key-marker': 'large-folder/file2.txt',
+            'version-id-marker': '222'
+        }
+
+        list_versions_body2 = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>false</IsTruncated>
+                <Version>
+                    <Key>large-folder/file2.txt</Key>
+                    <VersionId>222</VersionId>
+                </Version>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url2, params=params2, body=list_versions_body2, status=200)
+
+        # Mock the boto3 delete_objects call
+        mock_delete_response = {
+            'Deleted': [
+                {'Key': 'large-folder/file1.txt', 'VersionId': '111'},
+                {'Key': 'large-folder/file2.txt', 'VersionId': '222'}
+            ],
+            'Errors': []
+        }
+        provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
+
+        await provider._delete_folder(path)
+
+        # Verify both list versions requests were made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params1)
+        assert aiohttpretty.has_call(method='GET', uri=versions_url2, params=params2)
+
+        # Verify delete_objects was called once
+        provider.bucket.delete_objects.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_folder_not_found(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/not-found-folder/')
+        prefix = path.full_path.lstrip('/')  # 'not-found-folder/'
+
+        # Mock get_full_revision response with empty versions and delete_markers - bucket-level operation
+        query_params = {'Prefix': prefix}
+        versions_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params})
+        versions_params = {'prefix': prefix, 'versions': ''}
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <IsTruncated>false</IsTruncated>
+            </ListVersionsResult>'''
+        aiohttpretty.register_uri('GET', versions_url, params=versions_params,
+                                body=list_versions_body, status=200)
+
+        with pytest.raises(exceptions.NotFoundError):
+            await provider._delete_folder(path)
+
+        # Verify the request was made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=versions_params)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_folder_delete_error(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/error-folder/')
+
+        # Mock list versions response - bucket-level operation
+        query_params = {'Prefix': path.path}
+        versions_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params})
+        params = {'prefix': path.path, 'versions': ''}
+
+        list_versions_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult>
+                <Version>
+                    <Key>error-folder/file1.txt</Key>
+                    <VersionId>111</VersionId>
+                </Version>
+            </ListVersionsResult>'''
+
+        aiohttpretty.register_uri('GET', versions_url, params=params, body=list_versions_body, status=200)
+
+        # Mock failed delete_objects response
+        mock_delete_response = {
+            'Deleted': [],
+            'Errors': [
+                {
+                    'Key': 'error-folder/file1.txt',
+                    'VersionId': '111',
+                    'Code': 'AccessDenied',
+                    'Message': 'Access Denied'
+                }
+            ]
+        }
+        provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
+
+        with pytest.raises(exceptions.DeleteError):
+            await provider._delete_folder(path)
+
+        # Verify both requests were made
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
+        provider.bucket.delete_objects.assert_called_once()
+
+
+class TestMetadata:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_handle_data(self, provider):
+        data = ['txt001.txt', 'abc']
+        result, token = provider.handle_data(data)
+        assert compare_digest(token, 'abc')
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_folder(self, provider, folder_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/darp/', prepend=provider.prefix)
+        # Provider uses list_objects_v2 which doesn't take a key parameter, only query params
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url'
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url'
+        }
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        result = await provider.metadata(path)
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+        assert result[0].name == '   photos'
+        assert result[1].name == 'my-image.jpg'
+        assert result[2].extra['md5'] == '1b2cf535f27731c974343645a3985328'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_have_next_token(self, provider, folder_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/darp/')
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url',
+            'ContinuationToken': ''
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url',
+            'continuation-token': ''
+        }
+
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        result = await provider.metadata(path, revision=None, next_token='')
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+        assert result[0].name == '   photos'
+        assert result[1].name == 'my-image.jpg'
+        assert result[2].extra['md5'] == '1b2cf535f27731c974343645a3985328'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_folder_have_next_token(self, provider, folder_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/darp/')
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url',
+            'ContinuationToken': ''
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url',
+            'continuation-token': ''
+        }
+
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        result = await provider._metadata_folder(path, next_token='')
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+        assert result[0].name == '   photos'
+        assert result[1].name == 'my-image.jpg'
+        assert result[2].extra['md5'] == '1b2cf535f27731c974343645a3985328'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_folder_self_listing(self, provider, folder_and_contents, mock_time, generate_url_helper):
+        path = WaterButlerPath('/thisfolder/', prepend=provider.prefix)
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url'
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url'
+        }
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_and_contents)
+
+        result = await provider.metadata(path)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        for fobj in result[:-1]:
+            assert fobj.name != path.full_path
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_just_a_folder_metadata_folder(self, provider, folder_item_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/', prepend=provider.prefix)
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url'
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url'
+        }
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_item_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        result = await provider.metadata(path)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].kind == 'folder'
+
+    # @pytest.mark.asyncio
+    # @pytest.mark.aiohttpretty
+    # async def test_must_have_slash(self, provider, folder_item_metadata, mock_time):
+    #     with pytest.raises(exceptions.InvalidPathError):
+    #         await provider.metadata('')
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_empty_metadata_folder(self, provider, folder_empty_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/this-is-not-the-root/', prepend=provider.prefix)
+        metadata_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100, headers={}, query_parameters={})
+
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url'
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url'
+        }
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_empty_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        aiohttpretty.register_uri('HEAD', metadata_url, header=folder_empty_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        result = await provider.metadata(path)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_file(self, provider, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/Foo/Bar/my-image.jpg', prepend=provider.prefix)
+        url = generate_url_helper(key=path.full_path, method='HEAD', expires=100, headers={}, query_parameters={})
+        aiohttpretty.register_uri('HEAD', url, headers=file_header_metadata)
+
+        result = await provider.metadata(path)
+
+        assert isinstance(result, metadata.BaseFileMetadata)
+        assert result.path == '/' + path.path
+        assert result.name == 'my-image.jpg'
+        assert result.extra['md5'] == 'fba9dede5f27731c9771645a39863328'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_file_lastest_revision(self, provider, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/Foo/Bar/my-image.jpg', prepend=provider.prefix)
+        url = generate_url_helper(key=path.full_path, method='HEAD', expires=100, headers={}, query_parameters={})
+        aiohttpretty.register_uri('HEAD', url, headers=file_header_metadata)
+
+        result = await provider.metadata(path, revision='Latest')
+
+        assert isinstance(result, metadata.BaseFileMetadata)
+        assert result.path == '/' + path.path
+        assert result.name == 'my-image.jpg'
+        assert result.extra['md5'] == 'fba9dede5f27731c9771645a39863328'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_file_missing(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/notfound.txt', prepend=provider.prefix)
+        url = generate_url_helper(key=path.full_path, method='HEAD', expires=100, headers={}, query_parameters={})
+        aiohttpretty.register_uri('HEAD', url, status=404)
+
+        with pytest.raises(exceptions.MetadataError):
+            await provider.metadata(path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload(self, provider, file_content, file_stream, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        content_md5 = hashlib.md5(file_content).hexdigest()
+        url = generate_url_helper(key=path.full_path, method='PUT', expires=100, headers={}, query_parameters={})
+        metadata_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100, headers={}, query_parameters={})
+        aiohttpretty.register_uri(
+            'HEAD',
+            metadata_url,
+            responses=[
+                {'status': 404},
+                {'headers': file_header_metadata},
+            ],
+        )
+        headers = {'ETag': '"{}"'.format(content_md5)}
+        aiohttpretty.register_uri('PUT', url, status=200, headers=headers),
+
+        metadata, created = await provider.upload(file_stream, path)
+
+        assert metadata.kind == 'file'
+        assert created
+        assert aiohttpretty.has_call(method='PUT', uri=url)
+        assert aiohttpretty.has_call(method='HEAD', uri=metadata_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload_checksum_mismatch(self, provider, file_stream, file_header_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/foobah', prepend=provider.prefix)
+        url = generate_url_helper(key=path.full_path, method='PUT', expires=100, headers={}, query_parameters={})
+        metadata_url = generate_url_helper(key=path.full_path, method='HEAD', expires=100, headers={}, query_parameters={})
+        aiohttpretty.register_uri(
+            'HEAD',
+            metadata_url,
+            responses=[
+                {'status': 404},
+                {'headers': file_header_metadata},
+            ],
+        )
+        aiohttpretty.register_uri('PUT', url, status=200, headers={'ETag': '"bad hash"'})
+
+        with pytest.raises(exceptions.UploadChecksumMismatchError):
+            await provider.upload(file_stream, path)
+
+        assert aiohttpretty.has_call(method='PUT', uri=url)
+        assert aiohttpretty.has_call(method='HEAD', uri=metadata_url)
+
+
+class TestCreateFolder:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_raise_409(self, provider, folder_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/alreadyexists/', prepend=provider.prefix)
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url'
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url'
+        }
+        aiohttpretty.register_uri('GET', url, params=params, body=folder_metadata,
+                                  headers={'Content-Type': 'application/xml'})
+
+        with pytest.raises(exceptions.FolderNamingConflict) as e:
+            await provider.create_folder(path)
+
+        assert e.value.code == 409
+        assert e.value.message == 'Cannot create folder "alreadyexists", because a file or folder already exists with that name'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_must_start_with_slash(self, provider, mock_time):
+        path = WaterButlerPath('/alreadyexists', prepend=provider.prefix)
+
+        with pytest.raises(exceptions.CreateFolderError) as e:
+            await provider.create_folder(path)
+
+        assert e.value.code == 400
+        assert e.value.message == 'Path must be a directory'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_create_folder_with_folder_precheck_is_false(self, provider, mock_time):
+        path = WaterButlerPath('/alreadyexists', prepend=provider.prefix)
+
+        with pytest.raises(exceptions.CreateFolderError) as e:
+            await provider.create_folder(path, folder_precheck=False)
+
+        assert e.value.code == 400
+        assert e.value.message == 'Path must be a directory'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_errors_out(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/alreadyexists/')
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url'
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url'
+        }
+        create_url = generate_url_helper(key=path.full_path, method='PUT', expires=100, headers={}, query_parameters={})
+
+        aiohttpretty.register_uri('GET', url, params=params, status=404)
+        aiohttpretty.register_uri('PUT', create_url, status=403)
+
+        with pytest.raises(exceptions.CreateFolderError) as e:
+            await provider.create_folder(path)
+
+        assert e.value.code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_errors_out_metadata(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/alreadyexists/', prepend=provider.prefix)
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url'
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url'
+        }
+
+        aiohttpretty.register_uri('GET', url, params=params, status=403)
+
+        with pytest.raises(exceptions.MetadataError) as e:
+            await provider.create_folder(path)
+
+        assert e.value.code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_creates(self, provider, mock_time, generate_url_helper):
+        path = WaterButlerPath('/doesntalreadyexists/', prepend=provider.prefix)
+        query_params = {
+            'Prefix': path.full_path.lstrip('/'),
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url'
+        }
+        url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=query_params)
+        params = {
+            'list-type': '2',
+            'prefix': path.full_path.lstrip('/'),
+            'delimiter': '/',
+            'max-keys': '1000',
+            'encoding-type': 'url'
+        }
+        create_url = generate_url_helper(key=path.full_path, method='PUT', expires=100, headers={}, query_parameters={})
+
+        aiohttpretty.register_uri('GET', url, params=params, status=404)
+        aiohttpretty.register_uri('PUT', create_url, status=200)
+
+        resp = await provider.create_folder(path)
+
+        assert resp.kind == 'folder'
+        assert resp.name == 'doesntalreadyexists'
+        assert resp.path == '/' + path.path
+
+
+class TestOperations:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_version_metadata(self, provider, version_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/my-image.jpg', prepend=provider.prefix)
+        prefix = path.full_path.lstrip('/')
+        url = generate_url_helper(
+            method='GET',
+            expires=100,
+            headers={},
+            query_parameters={
+                'versions': '',
+                'Prefix': prefix,
+                'Delimiter': '/'
+            }
+        )
+        params = {
+            'versions': '',
+            'prefix': prefix,
+            'delimiter': '/',
+            'encoding-type': 'url'
+        }
+        aiohttpretty.register_uri('GET', url, params=params, status=200, body=version_metadata)
+
+        data = await provider.revisions(path)
+
+        assert isinstance(data, list)
+        assert len(data) == 3
+
+        for item in data:
+            assert hasattr(item, 'extra')
+            assert hasattr(item, 'version')
+            assert hasattr(item, 'version_identifier')
+
+        assert aiohttpretty.has_call(method='GET', uri=url, params=params)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_equality(self, provider, mock_time):
+        assert not provider.can_intra_copy(provider)
+        assert not provider.can_intra_move(provider)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_single_version_metadata(self, provider, single_version_metadata, mock_time, generate_url_helper):
+        path = WaterButlerPath('/single-version.file', prepend=provider.prefix)
+        prefix = path.full_path.lstrip('/')
+        url = generate_url_helper(
+            method='GET',
+            expires=100,
+            headers={},
+            query_parameters={
+                'versions': '',
+                'Prefix': prefix,
+                'Delimiter': '/'
+            }
+        )
+        params = {
+            'versions': '',
+            'prefix': prefix,
+            'delimiter': '/',
+            'encoding-type': 'url'
+        }
+
+        aiohttpretty.register_uri('GET',
+                                  url,
+                                  params=params,
+                                  status=200,
+                                  body=single_version_metadata)
+
+        data = await provider.revisions(path)
+
+        assert isinstance(data, list)
+        assert len(data) == 1
+
+        for item in data:
+            assert hasattr(item, 'extra')
+            assert hasattr(item, 'version')
+            assert hasattr(item, 'version_identifier')
+
+        assert aiohttpretty.has_call(method='GET', uri=url, params=params)
+
+    def test_can_intra_move(self, provider):
+
+        file_path = WaterButlerPath('/my-image.jpg', prepend=provider.prefix)
+        folder_path = WaterButlerPath('/folder/', folder=True, prepend=provider.prefix)
+
+        assert not provider.can_intra_move(provider)
+        assert not provider.can_intra_move(provider, file_path)
+        assert not provider.can_intra_move(provider, folder_path)
+
+    def test_can_intra_copy(self, provider):
+
+        file_path = WaterButlerPath('/my-image.jpg', prepend=provider.prefix)
+        folder_path = WaterButlerPath('/folder/', folder=True, prepend=provider.prefix)
+
+        assert not provider.can_intra_copy(provider)
+        assert not provider.can_intra_copy(provider, file_path)
+        assert not provider.can_intra_copy(provider, folder_path)
+
+    def test_can_duplicate_names(self, provider):
+        assert provider.can_duplicate_names()

--- a/tests/providers/s3compatsigv4/test_provider.py
+++ b/tests/providers/s3compatsigv4/test_provider.py
@@ -1670,9 +1670,7 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_delete_null_version(self, provider, mock_time, generate_url_helper):
-        """When VersionId is 'null' (MinIO without versioning), the provider
-        should use a direct DELETE request instead of delete_objects."""
+    async def test_delete(self, provider, mock_time, generate_url_helper):
         path = WaterButlerPath('/some-file', prepend=provider.prefix)
 
         # Mock the versions list response - list_object_versions is bucket-level, not object-level
@@ -1713,81 +1711,9 @@ class TestCRUD:
             </ListVersionsResult>'''
         aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_body)
 
-        # Mock the direct DELETE request (used when VersionId='null' is filtered out)
-        delete_url = generate_url_helper(key=path.full_path, method='DELETE', expires=100)
-        aiohttpretty.register_uri('DELETE', delete_url, status=204)
-
-        # delete_objects should NOT be called in this path
-        provider.bucket.delete_objects = mock.Mock()
-
-        await provider.delete(path)
-
-        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
-        assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
-        provider.bucket.delete_objects.assert_not_called()
-
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_delete_with_real_versions(self, provider, mock_time, generate_url_helper):
-        """When VersionId is a real value, the provider should use
-        delete_objects to batch-delete all versions."""
-        path = WaterButlerPath('/some-file', prepend=provider.prefix)
-
-        query_params = {
-            'Prefix': path.path.lstrip('/'),
-            'Delimiter': '/',
-            'VersionIdMarker': ''
-        }
-        versions_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params})
-        params = {
-            'prefix': path.path.lstrip('/'),
-            'delimiter': '/',
-            'version-id-marker': '',
-            'versions': ''
-        }
-        version_body = '''<?xml version="1.0" encoding="UTF-8"?>
-            <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
-                <Name>bucket</Name>
-                <Prefix>some-file</Prefix>
-                <KeyMarker/>
-                <VersionIdMarker/>
-                <MaxKeys>1000</MaxKeys>
-                <IsTruncated>false</IsTruncated>
-                <Version>
-                    <Key>some-file</Key>
-                    <VersionId>abc123</VersionId>
-                    <IsLatest>true</IsLatest>
-                    <LastModified>2023-01-01T00:00:00.000Z</LastModified>
-                    <ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
-                    <Size>0</Size>
-                    <Owner>
-                        <ID>owner</ID>
-                        <DisplayName>owner</DisplayName>
-                    </Owner>
-                    <StorageClass>STANDARD</StorageClass>
-                </Version>
-                <Version>
-                    <Key>some-file</Key>
-                    <VersionId>def456</VersionId>
-                    <IsLatest>false</IsLatest>
-                    <LastModified>2022-12-01T00:00:00.000Z</LastModified>
-                    <ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
-                    <Size>0</Size>
-                    <Owner>
-                        <ID>owner</ID>
-                        <DisplayName>owner</DisplayName>
-                    </Owner>
-                    <StorageClass>STANDARD</StorageClass>
-                </Version>
-            </ListVersionsResult>'''
-        aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_body)
-
         # Mock the boto3 delete_objects call
         mock_delete_response = {
-            'Deleted': [
-                {'Key': 'some-file', 'VersionId': 'abc123'},
-                {'Key': 'some-file', 'VersionId': 'def456'},
-            ],
+            'Deleted': [{'Key': 'some-file', 'VersionId': 'null'}],
             'Errors': []
         }
         provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
@@ -1795,12 +1721,10 @@ class TestCRUD:
         await provider.delete(path)
 
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
+        # Verify delete_objects was called with correct parameters
         provider.bucket.delete_objects.assert_called_once()
         call_args = provider.bucket.delete_objects.call_args
-        assert call_args[1]['Delete']['Objects'] == [
-            {'Key': path.full_path, 'VersionId': 'abc123'},
-            {'Key': path.full_path, 'VersionId': 'def456'},
-        ]
+        assert call_args[1]['Delete']['Objects'] == [{'Key': path.full_path, 'VersionId': 'null'}]
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -1837,6 +1761,20 @@ class TestCRUD:
             body=version_metadata,
             status=200
         )
+
+        # Mock _folder_prefix_exists check (list_objects_v2 with prefix stripped of trailing slash)
+        prefix_check_query = {
+            'Prefix': '',
+            'Delimiter': '/'
+        }
+        prefix_check_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=prefix_check_query)
+        prefix_check_params = {'prefix': '', 'delimiter': '/'}
+        prefix_check_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <IsTruncated>false</IsTruncated>
+            </ListBucketResult>'''
+        aiohttpretty.register_uri('GET', prefix_check_url, params=prefix_check_params,
+                                body=prefix_check_body, status=200)
 
         # Mock the boto3 delete_objects call
         mock_delete_response = {
@@ -1895,6 +1833,20 @@ class TestCRUD:
             'Errors': []
         }
         provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
+
+        # Mock _folder_prefix_exists check (list_objects_v2)
+        prefix_check_query = {
+            'Prefix': 'folder-to-delete',
+            'Delimiter': '/'
+        }
+        prefix_check_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=prefix_check_query)
+        prefix_check_params = {'prefix': 'folder-to-delete', 'delimiter': '/'}
+        prefix_check_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <IsTruncated>false</IsTruncated>
+            </ListBucketResult>'''
+        aiohttpretty.register_uri('GET', prefix_check_url, params=prefix_check_params,
+                                body=prefix_check_body, status=200)
 
         await provider._delete_folder(path)
 
@@ -1961,6 +1913,20 @@ class TestCRUD:
             'Errors': []
         }
         provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
+
+        # Mock _folder_prefix_exists check (list_objects_v2)
+        prefix_check_query = {
+            'Prefix': 'large-folder',
+            'Delimiter': '/'
+        }
+        prefix_check_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters=prefix_check_query)
+        prefix_check_params = {'prefix': 'large-folder', 'delimiter': '/'}
+        prefix_check_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <IsTruncated>false</IsTruncated>
+            </ListBucketResult>'''
+        aiohttpretty.register_uri('GET', prefix_check_url, params=prefix_check_params,
+                                body=prefix_check_body, status=200)
 
         await provider._delete_folder(path)
 

--- a/tests/providers/s3compatsigv4/test_provider.py
+++ b/tests/providers/s3compatsigv4/test_provider.py
@@ -1670,7 +1670,9 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_delete(self, provider, mock_time, generate_url_helper):
+    async def test_delete_null_version(self, provider, mock_time, generate_url_helper):
+        """When VersionId is 'null' (MinIO without versioning), the provider
+        should use a direct DELETE request instead of delete_objects."""
         path = WaterButlerPath('/some-file', prepend=provider.prefix)
 
         # Mock the versions list response - list_object_versions is bucket-level, not object-level
@@ -1711,9 +1713,81 @@ class TestCRUD:
             </ListVersionsResult>'''
         aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_body)
 
+        # Mock the direct DELETE request (used when VersionId='null' is filtered out)
+        delete_url = generate_url_helper(key=path.full_path, method='DELETE', expires=100)
+        aiohttpretty.register_uri('DELETE', delete_url, status=204)
+
+        # delete_objects should NOT be called in this path
+        provider.bucket.delete_objects = mock.Mock()
+
+        await provider.delete(path)
+
+        assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
+        assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
+        provider.bucket.delete_objects.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_with_real_versions(self, provider, mock_time, generate_url_helper):
+        """When VersionId is a real value, the provider should use
+        delete_objects to batch-delete all versions."""
+        path = WaterButlerPath('/some-file', prepend=provider.prefix)
+
+        query_params = {
+            'Prefix': path.path.lstrip('/'),
+            'Delimiter': '/',
+            'VersionIdMarker': ''
+        }
+        versions_url = generate_url_helper(method='GET', expires=100, headers={}, query_parameters={'versions': '', **query_params})
+        params = {
+            'prefix': path.path.lstrip('/'),
+            'delimiter': '/',
+            'version-id-marker': '',
+            'versions': ''
+        }
+        version_body = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
+                <Name>bucket</Name>
+                <Prefix>some-file</Prefix>
+                <KeyMarker/>
+                <VersionIdMarker/>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                <Version>
+                    <Key>some-file</Key>
+                    <VersionId>abc123</VersionId>
+                    <IsLatest>true</IsLatest>
+                    <LastModified>2023-01-01T00:00:00.000Z</LastModified>
+                    <ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
+                    <Size>0</Size>
+                    <Owner>
+                        <ID>owner</ID>
+                        <DisplayName>owner</DisplayName>
+                    </Owner>
+                    <StorageClass>STANDARD</StorageClass>
+                </Version>
+                <Version>
+                    <Key>some-file</Key>
+                    <VersionId>def456</VersionId>
+                    <IsLatest>false</IsLatest>
+                    <LastModified>2022-12-01T00:00:00.000Z</LastModified>
+                    <ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
+                    <Size>0</Size>
+                    <Owner>
+                        <ID>owner</ID>
+                        <DisplayName>owner</DisplayName>
+                    </Owner>
+                    <StorageClass>STANDARD</StorageClass>
+                </Version>
+            </ListVersionsResult>'''
+        aiohttpretty.register_uri('GET', versions_url, params=params, status=200, body=version_body)
+
         # Mock the boto3 delete_objects call
         mock_delete_response = {
-            'Deleted': [{'Key': 'some-file', 'VersionId': 'null'}],
+            'Deleted': [
+                {'Key': 'some-file', 'VersionId': 'abc123'},
+                {'Key': 'some-file', 'VersionId': 'def456'},
+            ],
             'Errors': []
         }
         provider.bucket.delete_objects = mock.Mock(return_value=mock_delete_response)
@@ -1721,10 +1795,12 @@ class TestCRUD:
         await provider.delete(path)
 
         assert aiohttpretty.has_call(method='GET', uri=versions_url, params=params)
-        # Verify delete_objects was called with correct parameters
         provider.bucket.delete_objects.assert_called_once()
         call_args = provider.bucket.delete_objects.call_args
-        assert call_args[1]['Delete']['Objects'] == [{'Key': path.full_path, 'VersionId': 'null'}]
+        assert call_args[1]['Delete']['Objects'] == [
+            {'Key': path.full_path, 'VersionId': 'abc123'},
+            {'Key': path.full_path, 'VersionId': 'def456'},
+        ]
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/waterbutler/providers/s3compatsigv4/__init__.py
+++ b/waterbutler/providers/s3compatsigv4/__init__.py
@@ -1,0 +1,1 @@
+from .provider import S3CompatSigV4Provider  # noqa

--- a/waterbutler/providers/s3compatsigv4/metadata.py
+++ b/waterbutler/providers/s3compatsigv4/metadata.py
@@ -1,0 +1,175 @@
+import os
+
+from waterbutler.core import metadata
+
+
+class S3CompatSigV4Metadata(metadata.BaseMetadata):
+
+    @property
+    def provider(self):
+        return self.raw['provider']
+
+    @property
+    def name(self):
+        return os.path.split(self.path)[1]
+
+    @staticmethod
+    def convert_prefix(provider, raw, key):
+        raw['provider'] = provider.NAME
+        raw[key] = raw[key][len(provider.prefix):].lstrip('/')
+
+
+class S3CompatSigV4FileMetadataHeaders(S3CompatSigV4Metadata, metadata.BaseFileMetadata):
+
+    def __init__(self, provider, path, headers):
+        # Cast to dict to clone as the headers will
+        # be destroyed when the request leaves scope
+        new_headers = dict(headers)
+        new_headers['Key'] = path
+        self.convert_prefix(provider, new_headers, 'Key')
+        super().__init__(new_headers)
+
+    @property
+    def path(self):
+        return '/' + self.raw['Key'].lstrip('/')
+
+    @property
+    def size(self):
+        return self.raw['Content-Length']
+
+    @property
+    def content_type(self):
+        return self.raw['Content-Type']
+
+    @property
+    def modified(self):
+        return self.raw['Last-Modified']
+
+    @property
+    def created_utc(self):
+        return None
+
+    @property
+    def etag(self):
+        # Handle case-insensitive header lookup
+        etag_value = self.raw.get('ETag', self.raw.get('Etag', ''))
+        return etag_value.replace('"', '')
+
+    @property
+    def extra(self):
+        # Handle case-insensitive header lookup
+        etag_value = self.raw.get('ETag', self.raw.get('Etag', ''))
+        return {
+            'md5': etag_value.replace('"', ''),
+            'encryption': self.raw.get('x-amz-server-side-encryption', '')
+        }
+
+
+class S3CompatSigV4FileMetadata(S3CompatSigV4Metadata, metadata.BaseFileMetadata):
+
+    def __init__(self, provider, raw):
+        new_raw = dict(raw)
+        self.convert_prefix(provider, new_raw, 'Key')
+        super().__init__(new_raw)
+
+    @property
+    def path(self):
+        return '/' + self.raw['Key'].lstrip('/')
+
+    @property
+    def size(self):
+        return int(self.raw['Size'])
+
+    @property
+    def modified(self):
+        return self.raw['LastModified']
+
+    @property
+    def created_utc(self):
+        return None
+
+    @property
+    def content_type(self):
+        return None  # TODO
+
+    @property
+    def etag(self):
+        return self.raw['ETag'].replace('"', '')
+
+    @property
+    def extra(self):
+        return {
+            'md5': self.raw['ETag'].replace('"', '')
+        }
+
+
+class S3CompatSigV4FolderKeyMetadata(S3CompatSigV4Metadata, metadata.BaseFolderMetadata):
+
+    def __init__(self, provider, raw):
+        new_raw = dict(raw)
+        self.convert_prefix(provider, new_raw, 'Key')
+        super().__init__(new_raw)
+
+    @property
+    def name(self):
+        return self.raw['Key'].split('/')[-2]
+
+    @property
+    def path(self):
+        return '/' + self.raw['Key'].lstrip('/')
+
+    @property
+    def created(self):
+        return self.raw.get('created_at')
+
+    @property
+    def modified(self):
+        return self.raw.get('modified_at')
+
+
+class S3CompatSigV4FolderMetadata(S3CompatSigV4Metadata, metadata.BaseFolderMetadata):
+
+    def __init__(self, provider, raw):
+        new_raw = dict(raw)
+        self.convert_prefix(provider, new_raw, 'Prefix')
+        super().__init__(new_raw)
+
+    @property
+    def name(self):
+        return self.raw['Prefix'].split('/')[-2]
+
+    @property
+    def path(self):
+        return '/' + self.raw['Prefix'].lstrip('/')
+
+    @property
+    def created(self):
+        return self.raw.get('created_at')
+
+    @property
+    def modified(self):
+        return self.raw.get('modified_at')
+
+
+# TODO dates!
+class S3CompatSigV4Revision(metadata.BaseFileRevisionMetadata):
+
+    @property
+    def version_identifier(self):
+        return 'version'
+
+    @property
+    def version(self):
+        if self.raw['IsLatest'] == 'true':
+            return 'Latest'
+        return self.raw['VersionId']
+
+    @property
+    def modified(self):
+        return self.raw['LastModified']
+
+    @property
+    def extra(self):
+        return {
+            'md5': self.raw['ETag'].replace('"', '')
+        }

--- a/waterbutler/providers/s3compatsigv4/metadata.py
+++ b/waterbutler/providers/s3compatsigv4/metadata.py
@@ -39,7 +39,7 @@ class S3CompatSigV4FileMetadataHeaders(S3CompatSigV4Metadata, metadata.BaseFileM
 
     @property
     def content_type(self):
-        return self.raw['Content-Type']
+        return self.raw.get('Content-Type', 'application/octet-stream')
 
     @property
     def modified(self):

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -1,0 +1,1094 @@
+import asyncio
+import hashlib
+import functools
+from http import HTTPStatus
+from urllib import parse
+import re
+import logging
+import xml.sax.saxutils
+from io import BytesIO
+import base64
+
+import xmltodict
+import boto3
+from botocore.config import Config
+
+from waterbutler.core import streams, provider, exceptions
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.core.utils import make_disposition
+from waterbutler.providers.s3compatsigv4 import settings
+from waterbutler.providers.s3compatsigv4.metadata import (
+    S3CompatSigV4Revision,
+    S3CompatSigV4FileMetadata,
+    S3CompatSigV4FolderMetadata,
+    S3CompatSigV4FolderKeyMetadata,
+    S3CompatSigV4FileMetadataHeaders,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def compute_md5(fp):
+    """Compute MD5 hash for file-like object."""
+    m = hashlib.md5()
+    data = fp.read()
+    m.update(data)
+    fp.seek(0)
+    return m.digest(), base64.b64encode(m.digest()).decode('utf-8')
+
+
+def prepare_xml_body_batches(object_dict, batch_size=1000):
+    """Generate batched XML payloads for multi-object delete (max 1000 objects per request).
+
+    :param dict object_dict: { key: [versionId, ...], ... }
+    :param int batch_size: number of <Object> entries per batch (<=1000 per AWS spec)
+    :return: yields bytes payloads
+    """
+    current_batch = []
+    for key, versions in object_dict.items():
+        for version in versions:
+            current_batch.append(
+                '<Object><Key>{}</Key><VersionId>{}</VersionId></Object>'.format(
+                    xml.sax.saxutils.escape(key), xml.sax.saxutils.escape(version)
+                )
+            )
+            if len(current_batch) >= batch_size:
+                yield ('<?xml version="1.0" encoding="UTF-8"?><Delete>{}</Delete>'
+                       .format(''.join(current_batch))).encode('utf-8')
+                current_batch = []
+    if current_batch:
+        yield ('<?xml version="1.0" encoding="UTF-8"?><Delete>{}</Delete>'
+               .format(''.join(current_batch))).encode('utf-8')
+
+
+class S3CompatSigV4Connection:
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
+                 endpoint_url=None, region_name=None, use_ssl=True,
+                 verify_ssl=True, addressing_style='auto'):
+        self.endpoint_url = endpoint_url
+        self.region_name = region_name
+        self.use_ssl = use_ssl
+        self.verify_ssl = verify_ssl
+
+        config = Config(
+            signature_version='s3v4',
+            s3={
+                'addressing_style': addressing_style  # 'path', 'virtual', or 'auto'
+            }
+        )
+
+        self.s3 = boto3.resource(
+            's3',
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+            config=config,
+            use_ssl=use_ssl,
+            verify=verify_ssl,
+        )
+
+    def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=settings.TEMP_URL_SECS, HttpMethod=None):
+        return self.s3.meta.client.generate_presigned_url(ClientMethod, Params=Params, ExpiresIn=ExpiresIn, HttpMethod=HttpMethod)
+
+
+class S3CompatSigV4Provider(provider.BaseProvider):
+    """Provider for S3 Compatible Storage (SigV4) service.
+
+    API docs: http://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html
+
+    Quirks:
+
+    * On S3, folders are not first-class objects, but are instead inferred
+      from the names of their children.  A regular DELETE request issued
+      against a folder will not work unless that folder is completely empty.
+      To fully delete an occupied folder, we must delete all of the comprising
+      objects.  Amazon provides a bulk delete operation to simplify this.
+
+    * A GET prefix query against a non-existent path returns 200
+    """
+
+    @property
+    def NAME(self):
+        return 's3compatsigv4'
+
+    CHUNK_SIZE = settings.CHUNK_SIZE
+    CONTIGUOUS_UPLOAD_SIZE_LIMIT = settings.CONTIGUOUS_UPLOAD_SIZE_LIMIT
+
+    def __init__(self, auth, credentials, settings, **kwargs):
+        """
+        :param dict auth: Not used
+        :param dict credentials: Dict containing `access_key`, `secret_key`, `host`
+        :param dict settings: Dict containing `bucket` and optional `region`, `prefix`
+        """
+        super().__init__(auth, credentials, settings, **kwargs)
+
+        host = credentials['host']
+        port = 443
+        m = re.match(r'^(.+)\:([0-9]+)$', host)
+        if m is not None:
+            host = m.group(1)
+            port = int(m.group(2))
+
+        is_secure = (port == 443)
+        protocol = 'https' if is_secure else 'http'
+        if port in (80, 443):
+            endpoint_url = '{}://{}'.format(protocol, host)
+        else:
+            endpoint_url = '{}://{}:{}'.format(protocol, host, port)
+
+        self.bucket_name = self.settings['bucket']
+        self.encrypt_uploads = self.settings.get('encrypt_uploads', False)
+        self.region = self.settings.get('region', None)
+        self.prefix = self.settings.get('prefix', '')
+
+        self.connection = S3CompatSigV4Connection(
+            aws_access_key_id=credentials['access_key'],
+            aws_secret_access_key=credentials['secret_key'],
+            endpoint_url=endpoint_url,
+            region_name=self.region,
+            use_ssl=is_secure,
+            verify_ssl=is_secure
+        )
+        self.bucket = self.connection.s3.Bucket(self.bucket_name)
+
+    async def validate_v1_path(self, path, **kwargs):
+        wbpath = WaterButlerPath(path, prepend=self.prefix)
+        if path == '/':
+            return wbpath
+
+        implicit_folder = path.endswith('/')
+
+        prefix = wbpath.full_path.lstrip('/')  # '/' -> '', '/A/B' -> 'A/B'
+        if implicit_folder:
+            query_parameters = {
+                'Bucket': self.bucket_name,
+                'Prefix': prefix,
+                'Delimiter': '/',
+            }
+            resp = await self.make_request(
+                'GET',
+                functools.partial(
+                    self.connection.generate_presigned_url,
+                    'list_objects_v2',
+                    Params=query_parameters,
+                    HttpMethod='GET',
+                ),
+                expects=(
+                    HTTPStatus.OK,
+                    HTTPStatus.NOT_FOUND,
+                ),
+                throws=exceptions.MetadataError,
+            )
+        else:
+            query_parameters = {'Bucket': self.bucket_name, 'Key': prefix}
+            resp = await self.make_request(
+                'HEAD',
+                functools.partial(
+                    self.connection.generate_presigned_url,
+                    'head_object',
+                    Params=query_parameters,
+                    HttpMethod='HEAD',
+                ),
+                expects=(
+                    HTTPStatus.OK,
+                    HTTPStatus.NOT_FOUND,
+                ),
+                throws=exceptions.MetadataError,
+            )
+
+        await resp.release()
+
+        if resp.status == HTTPStatus.NOT_FOUND:
+            raise exceptions.NotFoundError(str(prefix))
+
+        return wbpath
+
+    async def validate_path(self, path, **kwargs):
+        return WaterButlerPath(path, prepend=self.prefix)
+
+    def can_duplicate_names(self):
+        return True
+
+    @staticmethod
+    def _check_for_200_error(
+        response_body,
+        s3_api_name='S3 API',
+        exception_type=exceptions.UnhandledProviderError,
+    ):
+        """check an S3 API result with http status is 200 OK.
+
+        try to parse response body as a xml.
+        if the xml has an 'Error' element then raise an exception.
+
+        :param str response_body: API response body.
+        :param str s3_api_name: S3 API name for logging.
+        :param type exception_type: raise Exception type
+        """
+        try:
+            # memo: If no element, the parser will raise an ExpatError.
+            result = xmltodict.parse(response_body)
+        except Exception:
+            logger.warning(f'Couldn\'t parse {s3_api_name} result "{response_body}"')
+            raise
+
+        if 'Error' in result:
+            logger.warning(f'{s3_api_name} returned with an error "{response_body}"')
+            raise exception_type(
+                f'{s3_api_name} returned with an error.',
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+
+    async def download(self, path, accept_url=False, revision=None, range=None, **kwargs):
+        r"""Returns a ResponseWrapper (Stream) for the specified path
+        raises FileNotFoundError if the status from S3 is not 200
+
+        :param path: ( :class:`.WaterButlerPath` ) Path to the key you want to download
+        :param kwargs: (dict) Additional arguments that are ignored
+        :rtype: :class:`waterbutler.core.streams.ResponseStreamReader`
+        :raises: :class:`waterbutler.core.exceptions.DownloadError`
+        """
+        if not path.is_file:
+            raise exceptions.DownloadError('No file specified for download', code=HTTPStatus.BAD_REQUEST)
+
+        # MEMO: This is a workaround for the bug on some callers.
+        if revision is None and 'version' in kwargs:
+            revision = kwargs['version']
+
+        try:
+            pre_size, pre_etag = await self._get_content_whole_size(path, revision)
+            if range is not None:
+                # MEMO: range type is (int, int)
+                # see: core/provider.py _build_range_header()
+                s, e = range
+                if s is None or e is None:
+                    pre_size = None
+                elif s < 0 or s >= pre_size or e < 0 or e >= pre_size or e < s:
+                    pre_size = None
+                else:
+                    pre_size = e - s + 1
+        except exceptions.MetadataError:
+            pre_size = None
+            pre_etag = None
+
+        if not revision or revision.lower() == 'latest':
+            query_parameters = None
+        else:
+            query_parameters = {'VersionId': revision}
+
+        display_name = kwargs.get('display_name') or path.name
+        response_headers = {
+            'ResponseContentDisposition': make_disposition(display_name)
+        }
+
+        query_parameters_dict = {'Bucket': self.bucket_name, 'Key': path.full_path}
+        if query_parameters:
+            query_parameters_dict.update(query_parameters)
+        query_parameters_dict.update(response_headers)
+
+        headers = {}
+        resp = await self.make_request(
+            'GET',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'get_object',
+                Params=query_parameters_dict,
+                HttpMethod='GET',
+            ),
+            range=range,
+            headers=headers,
+            expects=(HTTPStatus.OK, HTTPStatus.PARTIAL_CONTENT),
+            throws=exceptions.DownloadError,
+        )
+
+        try:
+            get_etag = resp.headers['ETag'].replace('"', '')
+            if get_etag != pre_etag:
+                pre_size = None
+        except KeyError:
+            pass
+
+        download_stream = streams.ResponseStreamReader(resp)
+
+        if hasattr(download_stream, '_size') and download_stream._size is None:
+            # if the GetObject API doesn't return Content-Length header,
+            # use metadata content-size or range size instead of it.
+            download_stream._size = pre_size
+
+        return download_stream
+
+    async def _get_content_whole_size(self, path: WaterButlerPath, revision=None):
+        """get content whole size from path."""
+        metadata = await self.metadata(path, revision)
+        try:
+            size = metadata.size_as_int
+            etag = metadata.etag
+        except KeyError:
+            raise exceptions.MetadataError('Cannot get content size and ETag')
+        return size, etag
+
+    async def upload(self, stream, path, conflict='replace', **kwargs):
+        """Uploads the given stream to S3 Compatible Storage
+
+        :param waterbutler.core.streams.RequestWrapper stream: The stream to put to S3 Compatible Storage
+        :param path: ( :class:`.WaterButlerPath` ) The full path of the key to upload to/into
+
+        :rtype: dict, bool
+        """
+        path, exists = await self.handle_name_conflict(path, conflict=conflict)
+
+        if stream.size < self.CONTIGUOUS_UPLOAD_SIZE_LIMIT:
+            await self._contiguous_upload(stream, path)
+        else:
+            await self._chunked_upload(stream, path)
+
+        return (await self.metadata(path, **kwargs)), not exists
+
+    async def _contiguous_upload(self, stream, path):
+        """Uploads the given stream in one request."""
+
+        stream.add_writer('md5', streams.HashStreamWriter(hashlib.md5))
+
+        headers = {'Content-Length': str(stream.size)}
+
+        # this is usually set in boto3 presigned url, but do it here
+        # to be explicit about our header payloads for signing purposes
+        if self.encrypt_uploads:
+            headers['x-amz-server-side-encryption'] = 'AES256'
+
+        query_parameters = {'Bucket': self.bucket_name, 'Key': path.full_path}
+
+        resp = await self.make_request(
+            'PUT',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'put_object',
+                Params=query_parameters,
+                HttpMethod='PUT',
+            ),
+            data=stream,
+            skip_auto_headers={'CONTENT-TYPE'},
+            headers=headers,
+            expects=(
+                HTTPStatus.OK,
+                HTTPStatus.CREATED,
+            ),
+            throws=exceptions.UploadError,
+        )
+        await resp.release()
+
+        # md5 is returned as ETag header as long as server side encryption is not used.
+        if stream.writers['md5'].hexdigest != resp.headers['ETag'].replace('"', ''):
+            raise exceptions.UploadChecksumMismatchError()
+
+    async def _chunked_upload(self, stream, path):
+        """Uploads the given stream to S3 over multiple chunks"""
+
+        # Step 1. Create a multi-part upload session
+        session_upload_id = await self._create_upload_session(path)
+
+        try:
+            # Step 2. Break stream into chunks and upload them one by one
+            parts_metadata = await self._upload_parts(stream, path, session_upload_id)
+            # Step 3. Commit the parts and end the upload session
+            await self._complete_multipart_upload(path, session_upload_id, parts_metadata)
+        except Exception as err:
+            msg = 'An unexpected error has occurred during the multi-part upload.'
+            logger.error('{} upload_id={} error={!r}'.format(msg, session_upload_id, err))
+            aborted = await self._abort_chunked_upload(path, session_upload_id)
+            if aborted:
+                msg += '  The abort action failed to clean up the temporary file parts generated ' \
+                       'during the upload process.  Please manually remove them.'
+            raise exceptions.UploadError(msg)
+
+    async def _create_upload_session(self, path):
+        """This operation initiates a multipart upload and returns an upload ID. This upload ID is
+        used to associate all of the parts in the specific multipart upload. You specify this upload
+        ID in each of your subsequent upload part requests (see Upload Part). You also include this
+        upload ID in the final request to either complete or abort the multipart upload request.
+
+        Docs: https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html
+        """
+
+        headers = {}
+        # "Initiate Multipart Upload" supports AWS server-side encryption
+        if self.encrypt_uploads:
+            headers = {'x-amz-server-side-encryption': 'AES256'}
+
+        query_parameters = {'Bucket': self.bucket_name, 'Key': path.full_path}
+
+        resp = await self.make_request(
+            'POST',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'create_multipart_upload',
+                Params=query_parameters,
+                ExpiresIn=200,
+                HttpMethod='POST',
+            ),
+            headers=headers,
+            skip_auto_headers={'CONTENT-TYPE'},
+            expects=(
+                HTTPStatus.OK,
+                HTTPStatus.CREATED,
+            ),
+            throws=exceptions.UploadError,
+        )
+        upload_session_metadata = await resp.read()
+        session_data = xmltodict.parse(upload_session_metadata, strip_whitespace=False)
+        # Session upload id is the only info we need
+        return session_data['InitiateMultipartUploadResult']['UploadId']
+
+    async def _upload_parts(self, stream, path, session_upload_id):
+        """Uploads all parts/chunks of the given stream to S3 one by one."""
+
+        metadata = []
+        parts = [self.CHUNK_SIZE for i in range(0, stream.size // self.CHUNK_SIZE)]
+        if stream.size % self.CHUNK_SIZE:
+            parts.append(stream.size - (len(parts) * self.CHUNK_SIZE))
+        logger.debug('Multipart upload segment sizes: {}'.format(parts))
+        for chunk_number, chunk_size in enumerate(parts):
+            logger.debug('  uploading part {} with size {}'.format(chunk_number + 1, chunk_size))
+            metadata.append(await self._upload_part(stream, path, session_upload_id,
+                                                    chunk_number + 1, chunk_size))
+        return metadata
+
+    async def _upload_part(self, stream, path, session_upload_id, chunk_number, chunk_size):
+        """Uploads a single part/chunk of the given stream to S3.
+
+        :param int chunk_number: sequence number of chunk. 1-indexed.
+        """
+
+        cutoff_stream = streams.CutoffStream(stream, cutoff=chunk_size)
+
+        headers = {'Content-Length': str(chunk_size)}
+        query_parameters = {
+            'Bucket': self.bucket_name,
+            'Key': path.full_path,
+            'PartNumber': chunk_number,
+            'UploadId': session_upload_id,
+        }
+
+        resp = await self.make_request(
+            'PUT',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'upload_part',
+                Params=query_parameters,
+                ExpiresIn=200,
+                HttpMethod='PUT',
+            ),
+            data=cutoff_stream,
+            skip_auto_headers={'CONTENT-TYPE'},
+            headers=headers,
+            expects=(
+                HTTPStatus.OK,
+                HTTPStatus.CREATED,
+            ),
+            throws=exceptions.UploadError,
+        )
+        await resp.release()
+        return resp.headers
+
+    async def _abort_chunked_upload(self, path, session_upload_id):
+        """This operation aborts a multipart upload. After a multipart upload is aborted, no
+        additional parts can be uploaded using that upload ID. The storage consumed by any
+        previously uploaded parts will be freed. However, if any part uploads are currently in
+        progress, those part uploads might or might not succeed. As a result, it might be necessary
+        to abort a given multipart upload multiple times in order to completely free all storage
+        consumed by all parts. To verify that all parts have been removed, so you don't get charged
+        for the part storage, you should call the List Parts operation and ensure the parts list is
+        empty.
+
+        Docs: https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadAbort.html
+
+        Quirks:
+
+        If the ABORT request is successful, the session may be deleted when the LIST PARTS request
+        is made.  The criteria for successful abort thus is ether LIST PARTS request returns 404 or
+        returns 200 with an empty parts list.
+        """
+
+        headers = {}
+        query_parameters = {
+            'Bucket': self.bucket_name,
+            'Key': path.full_path,
+            'UploadId': session_upload_id,
+        }
+
+        iteration_count = 0
+        is_aborted = False
+        while iteration_count < settings.CHUNKED_UPLOAD_MAX_ABORT_RETRIES:
+            try:
+                # ABORT
+                resp = await self.make_request(
+                    'DELETE',
+                    functools.partial(
+                        self.connection.generate_presigned_url,
+                        'abort_multipart_upload',
+                        Params=query_parameters,
+                        HttpMethod='DELETE',
+                    ),
+                    skip_auto_headers={'CONTENT-TYPE'},
+                    headers=headers,
+                    expects=(HTTPStatus.NO_CONTENT,),
+                    throws=exceptions.UploadError,
+                )
+                await resp.release()
+
+                # LIST PARTS
+                resp_xml, session_deleted = await self._list_uploaded_chunks(path, session_upload_id)
+
+                if session_deleted:
+                    # Abort is successful if the session has been deleted
+                    is_aborted = True
+                    break
+
+                uploaded_chunks_list = xmltodict.parse(resp_xml, strip_whitespace=False)
+                parsed_parts_list = uploaded_chunks_list['ListPartsResult'].get('Part', [])
+                if len(parsed_parts_list) == 0:
+                    # Abort is successful when there is no part left
+                    is_aborted = True
+                    break
+            except Exception as err:
+                msg = 'An unexpected error has occurred during the aborting a multipart upload.'
+                logger.error('{} upload_id={} error={!r}'.format(msg, session_upload_id, err))
+
+            iteration_count += 1
+
+        if is_aborted:
+            logger.debug('Multi-part upload has been successfully aborted: retries={} '
+                         'upload_id={}'.format(iteration_count, session_upload_id))
+            return True
+
+        logger.error('Multi-part upload has failed to abort: retries={} '
+                     'upload_id={}'.format(iteration_count, session_upload_id))
+        return False
+
+    async def _list_uploaded_chunks(self, path, session_upload_id):
+        """This operation lists the parts that have been uploaded for a specific multipart upload.
+
+        Docs: https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html
+        """
+
+        headers = {}
+        query_parameters = {
+            'Bucket': self.bucket_name,
+            'Key': path.full_path,
+            'UploadId': session_upload_id,
+        }
+
+        resp = await self.make_request(
+            'GET',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'list_parts',
+                Params=query_parameters,
+                HttpMethod='GET',
+            ),
+            skip_auto_headers={'CONTENT-TYPE'},
+            headers=headers,
+            expects=(
+                HTTPStatus.OK,
+                HTTPStatus.CREATED,
+                HTTPStatus.NOT_FOUND,
+            ),
+            throws=exceptions.UploadError,
+        )
+        session_deleted = resp.status == HTTPStatus.NOT_FOUND
+        resp_xml = await resp.read()
+
+        return resp_xml, session_deleted
+
+    async def _complete_multipart_upload(self, path, session_upload_id, parts_metadata):
+        """This operation completes a multipart upload by assembling previously uploaded parts.
+
+        Docs: https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
+        """
+
+        payload = ''.join([
+            '<?xml version="1.0" encoding="UTF-8"?><CompleteMultipartUpload>',
+            ''.join(
+                ['<Part><PartNumber>{}</PartNumber><ETag>{}</ETag></Part>'.format(
+                    i + 1,
+                    xml.sax.saxutils.escape(part['ETAG'])
+                ) for i, part in enumerate(parts_metadata)]
+            ),
+            '</CompleteMultipartUpload>',
+        ]).encode('utf-8')
+        headers = {
+            'Content-Length': str(len(payload)),
+            'Content-MD5': compute_md5(BytesIO(payload))[1],
+            'Content-Type': 'text/xml',
+        }
+        query_parameters = {
+            'Bucket': self.bucket_name,
+            'Key': path.full_path,
+            'UploadId': session_upload_id
+        }
+
+        resp = await self.make_request(
+            'POST',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'complete_multipart_upload',
+                Params=query_parameters,
+                ExpiresIn=200,
+                HttpMethod='POST',
+            ),
+            data=payload,
+            headers=headers,
+            expects=(
+                HTTPStatus.OK,
+                HTTPStatus.CREATED,
+            ),
+            throws=exceptions.UploadError,
+        )
+
+        response_body = await resp.read()
+        self._check_for_200_error(response_body, "CompleteMultipartUpload", exceptions.UploadError)
+
+        await resp.release()
+
+    async def delete(self, path, confirm_delete=0, **kwargs):
+        """Delete the key and all its versions at the specified path
+
+        :param path: ( :class:`.WaterButlerPath` ) The path of the key to delete
+        :param int confirm_delete: Must be 1 to confirm root folder delete
+        """
+        if path.is_root:
+            if not confirm_delete == 1:
+                raise exceptions.DeleteError(
+                    'confirm_delete=1 is required for deleting root provider folder',
+                    code=HTTPStatus.BAD_REQUEST,
+                )
+        logger.info('Deleting path: %s', path.full_path)
+        if path.is_file:
+            # Retrieve and delete all versions (batched) similar to S3 provider
+            try:
+                prefix = path.full_path.lstrip('/')
+                query_params = {
+                    'Prefix': prefix,
+                    'Delimiter': '/',
+                    'VersionIdMarker': '',
+                }
+                _, versions, delete_markers = await self.get_full_revision(query_params)
+                full_version_list = versions + delete_markers
+                if full_version_list:
+                    version_dict = {
+                        path.full_path: [
+                            v.get('VersionId')
+                            for v in full_version_list
+                            if v.get('VersionId')
+                        ]
+                    }
+
+                    version_ids = version_dict[path.full_path]
+                    # AWS allows max 1000 objects per delete_objects call
+                    for i in range(0, len(version_ids), 1000):
+                        batch = version_ids[i: i + 1000]
+                        delete_list = [
+                            {'Key': path.full_path, 'VersionId': vid} for vid in batch
+                        ]
+                        # Run synchronous boto3 call in executor to avoid blocking
+                        loop = asyncio.get_event_loop()
+                        response = await loop.run_in_executor(
+                            None,
+                            lambda d=delete_list: self.bucket.delete_objects(
+                                Delete={'Objects': d, 'Quiet': False}
+                            ),
+                        )
+                        # Check for errors in response
+                        if 'Errors' in response and response['Errors']:
+                            error_msgs = [
+                                f'Key={e.get("Key")}, VersionId={e.get("VersionId")}, '
+                                f'Code={e.get("Code")}, Message={e.get("Message")}'
+                                for e in response["Errors"]
+                            ]
+                            logger.error(
+                                'Errors deleting objects: %s', '; '.join(error_msgs)
+                            )
+                            raise exceptions.DeleteError(
+                                f'Failed to delete some objects: {"; ".join(error_msgs[:3])}'
+                            )
+                        deleted_count = len(response.get('Deleted', []))
+                        logger.debug('Batch deleted %d versions', deleted_count)
+                else:
+                    # No versions -> delete current object directly
+                    query_parameters = {
+                        'Bucket': self.bucket_name,
+                        'Key': path.full_path,
+                    }
+                    resp = await self.make_request(
+                        'DELETE',
+                        functools.partial(
+                            self.connection.generate_presigned_url,
+                            'delete_object',
+                            Params=query_parameters,
+                            HttpMethod='DELETE',
+                        ),
+                        expects=(
+                            HTTPStatus.OK,
+                            HTTPStatus.NO_CONTENT,
+                        ),
+                        throws=exceptions.DeleteError,
+                    )
+                    await resp.release()
+            except exceptions.MetadataError:
+                # Skip if versions cannot be retrieved
+                # or if the file has no versions
+                # In this case, delete the current version directly
+                query_parameters = {'Bucket': self.bucket_name, 'Key': path.full_path}
+                resp = await self.make_request(
+                    'DELETE',
+                    functools.partial(
+                        self.connection.generate_presigned_url,
+                        'delete_object',
+                        Params=query_parameters,
+                        HttpMethod='DELETE',
+                    ),
+                    expects=(
+                        HTTPStatus.OK,
+                        HTTPStatus.NO_CONTENT,
+                    ),
+                    throws=exceptions.DeleteError,
+                )
+                await resp.release()
+        else:
+            await self._delete_folder(path, **kwargs)
+
+    async def _folder_prefix_exists(self, folder_prefix):
+        # Even if the storage is MinIO, Contents with a leaf folder is
+        # returned when a last slash of a prefix is removed.
+        query_parameters = {
+            'Bucket': self.bucket_name,
+            'Prefix': folder_prefix.rstrip('/'),  # 'A/B/' -> 'A/B'
+            'Delimiter': '/'
+        }
+        resp = await self.make_request(
+            'GET',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'list_objects_v2',
+                Params=query_parameters,
+                HttpMethod='GET',
+            ),
+            expects=(HTTPStatus.OK,),
+            throws=exceptions.MetadataError,
+        )
+        response_body = await resp.read()
+        parsed = xmltodict.parse(response_body, strip_whitespace=False)['ListBucketResult']
+        common_prefixes = parsed.get('CommonPrefixes', [])
+        # common_prefixes is dict when returned prefix is one.
+        if not isinstance(common_prefixes, list):
+            common_prefixes = [common_prefixes]
+        for common_prefix in common_prefixes:
+            val = common_prefix.get('Prefix')
+            if val == folder_prefix:  # with last slash
+                return True
+        return False
+
+    async def _delete_folder(self, path, **kwargs):
+        """Query for recursive contents of folder and delete in batches of 1000
+
+        Called from: func: delete if not path.is_file
+
+        Calls: func: self.make_request
+               func: self.connection.generate_presigned_url
+
+        :param *ProviderPath path: Path to be deleted
+
+        On S3, folders are not first-class objects, but are instead inferred
+        from the names of their children.  A regular DELETE request issued
+        against a folder will not work unless that folder is completely empty.
+        To fully delete an occupied folder, we must delete all of the comprising
+        objects.  Amazon provides a bulk delete operation to simplify this.
+        """
+        if not path.full_path.endswith('/'):
+            raise exceptions.InvalidParameters('not a folder: {}'.format(str(path)))
+
+        prefix = path.full_path.lstrip('/')
+        list_query_params = {'Prefix': prefix}
+        try:
+            parsed, versions, delete_markers = await self.get_full_revision(dict(list_query_params))
+        except exceptions.MetadataError:
+            # If versions unsupported, we cannot bulk-delete versions; fall back to NotFound or simple exit
+            # For safety, attempt a basic listing check
+            if await self._folder_prefix_exists(prefix):
+                # Nothing else to delete (no versions support), just return
+                return
+            raise
+
+        if not versions and not delete_markers:
+            # No objects/versions -> treat as missing (parity with S3 provider)
+            raise exceptions.NotFoundError(str(path))
+
+        version_map = {}
+        for item in versions + delete_markers:
+            key = item.get('Key')
+            version_id = item.get('VersionId')
+            if not key or not version_id:
+                continue
+            version_map.setdefault(key, []).append(version_id)
+
+        all_objects = [
+            {'Key': k, 'VersionId': v} for k, vids in version_map.items() for v in vids
+        ]
+        # AWS allows max 1000 objects per delete_objects call
+        for i in range(0, len(all_objects), 1000):
+            batch = all_objects[i: i + 1000]
+            # Run synchronous boto3 call in executor to avoid blocking
+            loop = asyncio.get_event_loop()
+            response = await loop.run_in_executor(
+                None,
+                lambda b=batch: self.bucket.delete_objects(
+                    Delete={'Objects': b, 'Quiet': False}
+                ),
+            )
+            # Check for errors in response
+            if 'Errors' in response and response['Errors']:
+                error_msgs = [
+                    f"Key={e.get('Key')}, VersionId={e.get('VersionId')}, "
+                    f"Code={e.get('Code')}, Message={e.get('Message')}"
+                    for e in response['Errors']
+                ]
+                logger.error(
+                    'Errors deleting folder objects: %s', '; '.join(error_msgs)
+                )
+                raise exceptions.DeleteError(
+                    f'Failed to delete some objects: {"; ".join(error_msgs[:3])}'
+                )
+            deleted_count = len(response.get('Deleted', []))
+            logger.debug('Batch deleted %d objects from folder', deleted_count)
+
+    async def get_full_revision(self, query_params):
+        """
+        Get all versions and delete markers of the requested object
+        :param query_params: The query parameters to be used in the request
+        :return: The dict of response content, list versions and delete_markers
+        """
+        versions = []
+        delete_markers = []
+        more_to_come = True
+
+        while more_to_come:
+            query_parameters_dict = {'Bucket': self.bucket_name}
+            query_parameters_dict.update(query_params)
+            resp = await self.make_request(
+                'GET',
+                functools.partial(
+                    self.connection.generate_presigned_url,
+                    'list_object_versions',
+                    Params=query_parameters_dict,
+                    HttpMethod='GET',
+                ),
+                expects=(HTTPStatus.OK,),
+                throws=exceptions.MetadataError,
+            )
+
+            response_body = await resp.read()
+            logger.debug('ListObjectVersions response: {}'.format(response_body.decode('utf-8')))
+            parsed = xmltodict.parse(response_body.decode('utf-8'), strip_whitespace=False)['ListVersionsResult']
+
+            # Append current page's versions and delete markers
+            current_versions = parsed.get('Version', [])
+            current_delete_markers = parsed.get('DeleteMarker', [])
+
+            if isinstance(current_versions, dict):
+                current_versions = [current_versions]
+            if isinstance(current_delete_markers, dict):
+                current_delete_markers = [current_delete_markers]
+
+            versions.extend(current_versions)
+            delete_markers.extend(current_delete_markers)
+
+            # Check if more pages are available
+            more_to_come = parsed.get('IsTruncated') == 'true'
+            if more_to_come:
+                query_params['KeyMarker'] = parsed.get('NextKeyMarker')
+                query_params['VersionIdMarker'] = parsed.get('NextVersionIdMarker')
+
+        return parsed, versions, delete_markers
+
+    async def revisions(self, path, **kwargs):
+        """Get past versions of the requested key
+
+        :param path: ( :class:`.WaterButlerPath` ) The path to a key
+        :rtype list:
+        """
+        prefix = path.full_path.lstrip('/')  # '/' -> '', '/A/B' -> 'A/B'
+        query_parameters = {
+            'Bucket': self.bucket_name,
+            'Prefix': prefix,
+            'Delimiter': '/'
+        }
+        list_url = self.connection.generate_presigned_url('list_object_versions', Params=query_parameters, ExpiresIn=settings.TEMP_URL_SECS, HttpMethod='GET')
+        try:
+            resp = await self.make_request(
+                'GET',
+                list_url,
+                expects=(HTTPStatus.OK,),
+                throws=exceptions.MetadataError,
+            )
+        except exceptions.MetadataError as e:
+            # MinIO may not support "versions" from boto3 presigned url.
+            # (And, MinIO does not support ListObjectVersions yet.)
+            logger.info('ListObjectVersions may not be supported: url={}: {}'.format(list_url, str(e)))
+            return []
+
+        response_body = await resp.read()
+        xml = xmltodict.parse(response_body.decode('utf-8'))
+        versions = xml['ListVersionsResult'].get('Version') or []
+
+        if isinstance(versions, dict):
+            versions = [versions]
+
+        return [
+            S3CompatSigV4Revision(item)
+            for item in versions
+            if item['Key'] == prefix
+        ]
+
+    async def metadata(self, path, revision=None, **kwargs):
+        """Get Metadata about the requested file or folder
+
+        :param WaterButlerPath path: The path to a key or folder
+        :rtype: dict or list
+        """
+        if path.is_dir:
+            if 'next_token' in kwargs:
+                return await self._metadata_folder(path, kwargs['next_token'])
+            return (await self._metadata_folder(path))
+
+        return (await self._metadata_file(path, revision=revision))
+
+    def handle_data(self, data):
+        token = None
+        if not isinstance(data, S3CompatSigV4FileMetadataHeaders):
+            token = data.pop()
+
+        return data, token or ''
+
+    async def create_folder(self, path, folder_precheck=True, **kwargs):
+        """
+        :param path: ( :class:`.WaterButlerPath` ) The path to create a folder at
+        """
+        WaterButlerPath.validate_folder(path)
+
+        if folder_precheck:
+            if (await self.exists(path)):
+                raise exceptions.FolderNamingConflict(path.name)
+
+        query_parameters = {'Bucket': self.bucket_name, 'Key': path.full_path}
+
+        async with self.request(
+            'PUT',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'put_object',
+                Params=query_parameters,
+                HttpMethod='PUT',
+            ),
+            skip_auto_headers={'CONTENT-TYPE'},
+            expects=(
+                HTTPStatus.OK,
+                HTTPStatus.CREATED,
+            ),
+            throws=exceptions.CreateFolderError,
+        ):
+            return S3CompatSigV4FolderMetadata(self, {'Prefix': path.full_path})
+
+    async def _metadata_file(self, path, revision=None):
+        if revision == 'Latest':
+            revision = None
+        query_parameters = {'Bucket': self.bucket_name, 'Key': path.full_path}
+        if revision:
+            query_parameters['VersionId'] = revision
+
+        resp = await self.make_request(
+            'HEAD',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'head_object',
+                Params=query_parameters,
+                HttpMethod='HEAD',
+            ),
+            expects=(HTTPStatus.OK,),
+            throws=exceptions.MetadataError,
+        )
+        await resp.release()
+        return S3CompatSigV4FileMetadataHeaders(self, path.full_path, resp.headers)
+
+    async def _metadata_folder(self, path, next_token=None):
+        prefix = path.full_path.lstrip('/')  # '/' -> '', '/A/B' -> 'A/B'
+        query_parameters = {
+            'Bucket': self.bucket_name,
+            'Prefix': prefix,
+            'Delimiter': '/',
+            'MaxKeys': 1000,
+            'EncodingType': 'url',
+        }
+        if next_token is not None:
+            query_parameters['ContinuationToken'] = next_token
+
+        resp = await self.make_request(
+            'GET',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'list_objects_v2',
+                Params=query_parameters,
+                HttpMethod='GET',
+            ),
+            expects=(HTTPStatus.OK,),
+            throws=exceptions.MetadataError,
+        )
+
+        contents = await resp.read()
+        logger.info('S3CompatSigV4Provider._metadata_folder: %s', contents)
+        parsed = xmltodict.parse(parse.unquote_plus(contents.decode('utf-8')), strip_whitespace=False)['ListBucketResult']
+
+        next_token_string = parsed.get('NextMarker', '')
+        contents = parsed.get('Contents', [])
+        prefixes = parsed.get('CommonPrefixes', [])
+
+        if not contents and not prefixes and not path.is_root:
+            # If contents and prefixes are empty then this "folder"
+            # must exist as a key with a / at the end of the name
+            # if the path is root there is no need to test if it exists
+            query_parameters = {'Bucket': self.bucket_name, 'Key': prefix}
+            resp = await self.make_request(
+                'HEAD',
+                functools.partial(
+                    self.connection.generate_presigned_url,
+                    'head_object',
+                    Params=query_parameters,
+                    HttpMethod='HEAD',
+                ),
+                expects=(HTTPStatus.OK,),
+                throws=exceptions.MetadataError,
+            )
+            await resp.release()
+
+        if isinstance(contents, dict):
+            contents = [contents]
+
+        if isinstance(prefixes, dict):
+            prefixes = [prefixes]
+
+        items = [
+            S3CompatSigV4FolderMetadata(self, item)
+            for item in prefixes
+        ]
+
+        for content in contents:
+            if content['Key'] == path.full_path:  # self
+                continue
+
+            if content['Key'].endswith('/'):
+                items.append(S3CompatSigV4FolderKeyMetadata(self, content))
+            else:
+                items.append(S3CompatSigV4FileMetadata(self, content))
+
+        if next_token_string:
+            items.append(S3CompatSigV4FolderMetadata(self, {'Key': next_token_string}))
+        return items

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -886,6 +886,9 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                         error_count = len(response['Errors'])
                         error_codes = [e.get('Code', 'Unknown') for e in response['Errors']]
                         logger.error('_delete_folder fallback: %d delete error(s), codes=%s', error_count, error_codes)
+                        raise exceptions.DeleteError(
+                            'Failed to delete some objects: {} error(s)'.format(error_count)
+                        )
             # Also clean up folder prefix
             try:
                 await self._delete_folder_prefix(prefix)
@@ -1136,11 +1139,29 @@ class S3CompatSigV4Provider(provider.BaseProvider):
         )
 
         contents = await resp.read()
-        parsed = xmltodict.parse(parse.unquote_plus(contents.decode('utf-8')), strip_whitespace=False)['ListBucketResult']
+        parsed = xmltodict.parse(contents.decode('utf-8'), strip_whitespace=False)['ListBucketResult']
 
-        next_token_string = parsed.get('NextMarker', '')
+        next_token_string = parsed.get('NextContinuationToken', '')
         contents = parsed.get('Contents', [])
         prefixes = parsed.get('CommonPrefixes', [])
+
+        # Decode URL-encoded fields after XML parsing (not before).
+        # EncodingType=url causes S3 to URL-encode specific fields (Key, Prefix, etc.)
+        # but decoding the entire XML before parsing would break XML with
+        # special characters (e.g. & in key names).
+        if parsed.get('EncodingType') == 'url':
+            if isinstance(contents, dict):
+                contents = [contents]
+            for item in contents:
+                if 'Key' in item:
+                    item['Key'] = parse.unquote(item['Key'])
+            if isinstance(prefixes, dict):
+                prefixes = [prefixes]
+            for item in prefixes:
+                if 'Prefix' in item:
+                    item['Prefix'] = parse.unquote(item['Prefix'])
+            if next_token_string:
+                next_token_string = parse.unquote(next_token_string)
 
         if not contents and not prefixes and not path.is_root:
             # If contents and prefixes are empty then this "folder"

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -682,63 +682,40 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                         path.full_path: [
                             v.get('VersionId')
                             for v in full_version_list
-                            if v.get('VersionId') and v.get('VersionId') != 'null'
+                            if v.get('VersionId')
                         ]
                     }
 
                     version_ids = version_dict[path.full_path]
-                    if not version_ids:
-                        # No real version IDs (e.g. MinIO without versioning returns 'null')
-                        # Delete the current object directly without specifying VersionId
-                        query_parameters = {
-                            'Bucket': self.bucket_name,
-                            'Key': path.full_path,
-                        }
-                        resp = await self.make_request(
-                            'DELETE',
-                            functools.partial(
-                                self.connection.generate_presigned_url,
-                                'delete_object',
-                                Params=query_parameters,
-                                HttpMethod='DELETE',
+                    # AWS allows max 1000 objects per delete_objects call
+                    for i in range(0, len(version_ids), 1000):
+                        batch = version_ids[i: i + 1000]
+                        delete_list = [
+                            {'Key': path.full_path, 'VersionId': vid} for vid in batch
+                        ]
+                        # Run synchronous boto3 call in executor to avoid blocking
+                        loop = asyncio.get_event_loop()
+                        response = await loop.run_in_executor(
+                            None,
+                            lambda d=delete_list: self.bucket.delete_objects(
+                                Delete={'Objects': d, 'Quiet': False}
                             ),
-                            expects=(
-                                HTTPStatus.OK,
-                                HTTPStatus.NO_CONTENT,
-                            ),
-                            throws=exceptions.DeleteError,
                         )
-                        await resp.release()
-                    else:
-                        # AWS allows max 1000 objects per delete_objects call
-                        for i in range(0, len(version_ids), 1000):
-                            batch = version_ids[i: i + 1000]
-                            delete_list = [
-                                {'Key': path.full_path, 'VersionId': vid} for vid in batch
+                        # Check for errors in response
+                        if 'Errors' in response and response['Errors']:
+                            error_msgs = [
+                                f'Key={e.get("Key")}, VersionId={e.get("VersionId")}, '
+                                f'Code={e.get("Code")}, Message={e.get("Message")}'
+                                for e in response["Errors"]
                             ]
-                            # Run synchronous boto3 call in executor to avoid blocking
-                            loop = asyncio.get_event_loop()
-                            response = await loop.run_in_executor(
-                                None,
-                                lambda d=delete_list: self.bucket.delete_objects(
-                                    Delete={'Objects': d, 'Quiet': False}
-                                ),
+                            logger.error(
+                                'Errors deleting objects: %s', '; '.join(error_msgs)
                             )
-                            # Check for errors in response
-                            if 'Errors' in response and response['Errors']:
-                                error_msgs = [
-                                    f'Key={e.get("Key")}, VersionId={e.get("VersionId")}, '
-                                    f'Code={e.get("Code")}, Message={e.get("Message")}'
-                                    for e in response["Errors"]
-                                ]
-                                logger.error(
-                                    'Errors deleting objects: %s', '; '.join(error_msgs)
-                                )
-                                raise exceptions.DeleteError(
-                                    f'Failed to delete some objects: {"; ".join(error_msgs[:3])}'
-                                )
-                            deleted_count = len(response.get('Deleted', []))
-                            logger.debug('Batch deleted %d versions', deleted_count)
+                            raise exceptions.DeleteError(
+                                f'Failed to delete some objects: {"; ".join(error_msgs[:3])}'
+                            )
+                        deleted_count = len(response.get('Deleted', []))
+                        logger.debug('Batch deleted %d versions', deleted_count)
                 else:
                     # No versions -> delete current object directly
                     query_parameters = {
@@ -926,10 +903,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             if not key:
                 continue
             version_id = item.get('VersionId')
-            # MinIO without versioning returns VersionId='null' (string).
-            # Passing VersionId='null' to delete_objects does not actually
-            # delete objects on MinIO, so treat it as no version.
-            if version_id and version_id != 'null':
+            if version_id:
                 version_map.setdefault(key, []).append(version_id)
             else:
                 keys_without_version.append({'Key': key})
@@ -1006,6 +980,18 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             if isinstance(current_delete_markers, dict):
                 current_delete_markers = [current_delete_markers]
 
+            # boto3 automatically adds encoding-type=url to presigned URLs
+            # for list_object_versions, causing MinIO to return URL-encoded
+            # keys (e.g. Japanese characters). Decode them so that
+            # delete_objects receives the actual key names.
+            if parsed.get('EncodingType') == 'url':
+                for item in current_versions:
+                    if 'Key' in item:
+                        item['Key'] = parse.unquote(item['Key'])
+                for item in current_delete_markers:
+                    if 'Key' in item:
+                        item['Key'] = parse.unquote(item['Key'])
+
             versions.extend(current_versions)
             delete_markers.extend(current_delete_markers)
 
@@ -1013,6 +999,8 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             more_to_come = parsed.get('IsTruncated') == 'true'
             if more_to_come:
                 query_params['KeyMarker'] = parsed.get('NextKeyMarker')
+                if parsed.get('EncodingType') == 'url' and query_params['KeyMarker']:
+                    query_params['KeyMarker'] = parse.unquote(query_params['KeyMarker'])
                 query_params['VersionIdMarker'] = parsed.get('NextVersionIdMarker')
 
         return parsed, versions, delete_markers

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -6,6 +6,7 @@ from urllib import parse
 import re
 import logging
 import xml.sax.saxutils
+from xml.parsers.expat import ExpatError
 from io import BytesIO
 import base64
 
@@ -204,7 +205,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
         try:
             # memo: If no element, the parser will raise an ExpatError.
             result = xmltodict.parse(response_body)
-        except Exception:
+        except ExpatError:
             logger.warning(f'Couldn\'t parse {s3_api_name} result "{response_body}"')
             raise
 
@@ -377,11 +378,11 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             parts_metadata = await self._upload_parts(stream, path, session_upload_id)
             # Step 3. Commit the parts and end the upload session
             await self._complete_multipart_upload(path, session_upload_id, parts_metadata)
-        except Exception as err:
+        except exceptions.UploadError as err:
             msg = 'An unexpected error has occurred during the multi-part upload.'
             logger.error('{} upload_id={} error={!r}'.format(msg, session_upload_id, err))
             aborted = await self._abort_chunked_upload(path, session_upload_id)
-            if aborted:
+            if not aborted:
                 msg += '  The abort action failed to clean up the temporary file parts generated ' \
                        'during the upload process.  Please manually remove them.'
             raise exceptions.UploadError(msg)
@@ -535,7 +536,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                     # Abort is successful when there is no part left
                     is_aborted = True
                     break
-            except Exception as err:
+            except (exceptions.UploadError, ExpatError) as err:
                 msg = 'An unexpected error has occurred during the aborting a multipart upload.'
                 logger.error('{} upload_id={} error={!r}'.format(msg, session_upload_id, err))
 
@@ -648,8 +649,8 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             prefix = src_path.full_path.lstrip('/')
             try:
                 await self._delete_folder_prefix(prefix)
-            except Exception:
-                pass
+            except exceptions.DeleteError:
+                logger.warning('Failed to clean up folder prefix after move: %s', prefix)
 
         return result
 
@@ -886,8 +887,8 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             # Also clean up folder prefix
             try:
                 await self._delete_folder_prefix(prefix)
-            except Exception:
-                pass
+            except exceptions.DeleteError:
+                logger.warning('Failed to clean up folder prefix in _delete_folder fallback: %s', prefix)
             return
 
         if not versions and not delete_markers:

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -331,7 +331,10 @@ class S3CompatSigV4Provider(provider.BaseProvider):
         # Create a new stream from the data
         upload_stream = streams.StringStream(stream_data)
 
-        headers = {'Content-MD5': md5_base64}
+        headers = {
+            'Content-Length': str(len(stream_data)),
+            'Content-MD5': md5_base64,
+        }
 
         # this is usually set in boto3 presigned url, but do it here
         # to be explicit about our header payloads for signing purposes

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -865,7 +865,6 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 if isinstance(objects, dict):
                     objects = [objects]
                 all_objects.extend({'Key': obj['Key']} for obj in objects if obj.get('Key'))
-                logger.info('_delete_folder fallback: prefix=%s, found %d objects: %s', prefix, len(all_objects), [o['Key'] for o in all_objects[:10]])
 
                 if parsed.get('IsTruncated') == 'true':
                     continuation_token = parsed.get('NextContinuationToken')
@@ -882,7 +881,6 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                             Delete={'Objects': d, 'Quiet': False}
                         ),
                     )
-                    logger.info('_delete_folder fallback: deleted batch of %d objects', len(batch))
                     if response.get('Errors'):
                         logger.error('_delete_folder fallback: delete errors: %s', response['Errors'])
             # Also clean up folder prefix

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -381,11 +381,11 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             parts_metadata = await self._upload_parts(stream, path, session_upload_id)
             # Step 3. Commit the parts and end the upload session
             await self._complete_multipart_upload(path, session_upload_id, parts_metadata)
-        except exceptions.UploadError as err:
+        except Exception as err:
             msg = 'An unexpected error has occurred during the multi-part upload.'
             logger.error('{} upload_id={} error={!r}'.format(msg, session_upload_id, err))
             aborted = await self._abort_chunked_upload(path, session_upload_id)
-            if not aborted:
+            if aborted:
                 msg += '  The abort action failed to clean up the temporary file parts generated ' \
                        'during the upload process.  Please manually remove them.'
             raise exceptions.UploadError(msg)
@@ -539,7 +539,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                     # Abort is successful when there is no part left
                     is_aborted = True
                     break
-            except (exceptions.UploadError, ExpatError) as err:
+            except Exception as err:
                 msg = 'An unexpected error has occurred during the aborting a multipart upload.'
                 logger.error('{} upload_id={} error={!r}'.format(msg, session_upload_id, err))
 

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -635,6 +635,22 @@ class S3CompatSigV4Provider(provider.BaseProvider):
 
         await resp.release()
 
+    async def move(self, dest_provider, src_path, dest_path,
+                  rename=None, conflict='replace', handle_naming=True):
+        """Override move to clean up orphaned S3 folder prefix objects after move."""
+        result = await super().move(
+            dest_provider, src_path, dest_path,
+            rename=rename, conflict=conflict, handle_naming=handle_naming,
+        )
+
+        # After moving a folder, clean up orphaned folder prefix object at source
+        if not src_path.is_file:
+            prefix = src_path.full_path.lstrip('/')
+            if await self._folder_prefix_exists(prefix):
+                await self._delete_folder_prefix(prefix)
+
+        return result
+
     async def delete(self, path, confirm_delete=0, **kwargs):
         """Delete the key and all its versions at the specified path
 

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -206,11 +206,12 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             # memo: If no element, the parser will raise an ExpatError.
             result = xmltodict.parse(response_body)
         except ExpatError:
-            logger.warning(f'Couldn\'t parse {s3_api_name} result "{response_body}"')
+            logger.warning('Couldn\'t parse %s result', s3_api_name)
             raise
 
         if 'Error' in result:
-            logger.warning(f'{s3_api_name} returned with an error "{response_body}"')
+            error_code = result['Error'].get('Code', 'Unknown')
+            logger.warning('%s returned with an error: %s', s3_api_name, error_code)
             raise exception_type(
                 f'{s3_api_name} returned with an error.',
                 code=HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -245,6 +246,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 else:
                     pre_size = e - s + 1
         except exceptions.MetadataError:
+            logger.debug('Could not retrieve metadata for pre-flight check, skipping')
             pre_size = None
             pre_etag = None
 
@@ -283,6 +285,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             if get_etag != pre_etag:
                 pre_size = None
         except KeyError:
+            # ETag header may not be present in all responses
             pass
 
         download_stream = streams.ResponseStreamReader(resp)
@@ -666,7 +669,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                     'confirm_delete=1 is required for deleting root provider folder',
                     code=HTTPStatus.BAD_REQUEST,
                 )
-        logger.info('Deleting path: %s', path.full_path)
+        logger.debug('Deleting path: %s', path.full_path)
         if path.is_file:
             # Retrieve and delete all versions (batched) similar to S3 provider
             try:
@@ -704,16 +707,13 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                         )
                         # Check for errors in response
                         if 'Errors' in response and response['Errors']:
-                            error_msgs = [
-                                f'Key={e.get("Key")}, VersionId={e.get("VersionId")}, '
-                                f'Code={e.get("Code")}, Message={e.get("Message")}'
-                                for e in response["Errors"]
-                            ]
+                            error_count = len(response['Errors'])
+                            error_codes = [e.get('Code', 'Unknown') for e in response['Errors']]
                             logger.error(
-                                'Errors deleting objects: %s', '; '.join(error_msgs)
+                                'Errors deleting objects: count=%d, codes=%s', error_count, error_codes
                             )
                             raise exceptions.DeleteError(
-                                f'Failed to delete some objects: {"; ".join(error_msgs[:3])}'
+                                'Failed to delete some objects: {} error(s)'.format(error_count)
                             )
                         deleted_count = len(response.get('Deleted', []))
                         logger.debug('Batch deleted %d versions', deleted_count)
@@ -739,9 +739,9 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                     )
                     await resp.release()
             except exceptions.MetadataError:
-                # Skip if versions cannot be retrieved
-                # or if the file has no versions
-                # In this case, delete the current version directly
+                # Versions cannot be retrieved (e.g. MinIO without versioning).
+                # Fall back to deleting the current version directly.
+                logger.debug('Version listing not available, falling back to direct delete')
                 query_parameters = {'Bucket': self.bucket_name, 'Key': path.full_path}
                 resp = await self.make_request(
                     'DELETE',
@@ -883,7 +883,9 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                         ),
                     )
                     if response.get('Errors'):
-                        logger.error('_delete_folder fallback: delete errors: %s', response['Errors'])
+                        error_count = len(response['Errors'])
+                        error_codes = [e.get('Code', 'Unknown') for e in response['Errors']]
+                        logger.error('_delete_folder fallback: %d delete error(s), codes=%s', error_count, error_codes)
             # Also clean up folder prefix
             try:
                 await self._delete_folder_prefix(prefix)
@@ -923,16 +925,13 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             )
             # Check for errors in response
             if 'Errors' in response and response['Errors']:
-                error_msgs = [
-                    f"Key={e.get('Key')}, VersionId={e.get('VersionId')}, "
-                    f"Code={e.get('Code')}, Message={e.get('Message')}"
-                    for e in response['Errors']
-                ]
+                error_count = len(response['Errors'])
+                error_codes = [e.get('Code', 'Unknown') for e in response['Errors']]
                 logger.error(
-                    'Errors deleting folder objects: %s', '; '.join(error_msgs)
+                    'Errors deleting folder objects: count=%d, codes=%s', error_count, error_codes
                 )
                 raise exceptions.DeleteError(
-                    f'Failed to delete some objects: {"; ".join(error_msgs[:3])}'
+                    'Failed to delete some objects: {} error(s)'.format(error_count)
                 )
             deleted_count = len(response.get('Deleted', []))
             logger.debug('Batch deleted %d objects from folder', deleted_count)
@@ -967,7 +966,6 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             )
 
             response_body = await resp.read()
-            logger.debug('ListObjectVersions response: {}'.format(response_body.decode('utf-8')))
             parsed = xmltodict.parse(response_body.decode('utf-8'), strip_whitespace=False)['ListVersionsResult']
 
             # Append current page's versions and delete markers
@@ -1027,7 +1025,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
         except exceptions.MetadataError as e:
             # MinIO may not support "versions" from boto3 presigned url.
             # (And, MinIO does not support ListObjectVersions yet.)
-            logger.info('ListObjectVersions may not be supported: url={}: {}'.format(list_url, str(e)))
+            logger.info('ListObjectVersions may not be supported: %s', str(e))
             return []
 
         response_body = await resp.read()

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -37,30 +37,6 @@ def compute_md5(fp):
     return m.digest(), base64.b64encode(m.digest()).decode('utf-8')
 
 
-def prepare_xml_body_batches(object_dict, batch_size=1000):
-    """Generate batched XML payloads for multi-object delete (max 1000 objects per request).
-
-    :param dict object_dict: { key: [versionId, ...], ... }
-    :param int batch_size: number of <Object> entries per batch (<=1000 per AWS spec)
-    :return: yields bytes payloads
-    """
-    current_batch = []
-    for key, versions in object_dict.items():
-        for version in versions:
-            current_batch.append(
-                '<Object><Key>{}</Key><VersionId>{}</VersionId></Object>'.format(
-                    xml.sax.saxutils.escape(key), xml.sax.saxutils.escape(version)
-                )
-            )
-            if len(current_batch) >= batch_size:
-                yield ('<?xml version="1.0" encoding="UTF-8"?><Delete>{}</Delete>'
-                       .format(''.join(current_batch))).encode('utf-8')
-                current_batch = []
-    if current_batch:
-        yield ('<?xml version="1.0" encoding="UTF-8"?><Delete>{}</Delete>'
-               .format(''.join(current_batch))).encode('utf-8')
-
-
 class S3CompatSigV4Connection:
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  endpoint_url=None, region_name=None, use_ssl=True,
@@ -347,9 +323,15 @@ class S3CompatSigV4Provider(provider.BaseProvider):
     async def _contiguous_upload(self, stream, path):
         """Uploads the given stream in one request."""
 
-        stream.add_writer('md5', streams.HashStreamWriter(hashlib.md5))
+        # Read the entire stream to compute MD5
+        stream_data = await stream.read()
+        md5_digest = hashlib.md5(stream_data).digest()
+        md5_base64 = base64.b64encode(md5_digest).decode('utf-8')
 
-        headers = {'Content-Length': str(stream.size)}
+        # Create a new stream from the data
+        upload_stream = streams.StringStream(stream_data)
+
+        headers = {'Content-MD5': md5_base64}
 
         # this is usually set in boto3 presigned url, but do it here
         # to be explicit about our header payloads for signing purposes
@@ -366,7 +348,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 Params=query_parameters,
                 HttpMethod='PUT',
             ),
-            data=stream,
+            data=upload_stream,
             skip_auto_headers={'CONTENT-TYPE'},
             headers=headers,
             expects=(
@@ -375,11 +357,11 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             ),
             throws=exceptions.UploadError,
         )
-        await resp.release()
 
-        # md5 is returned as ETag header as long as server side encryption is not used.
-        if stream.writers['md5'].hexdigest != resp.headers['ETag'].replace('"', ''):
-            raise exceptions.UploadChecksumMismatchError()
+        # S3-compatible server automatically validates Content-MD5
+        # If MD5 doesn't match, server returns 400 UploadError before writing data
+
+        await resp.release()
 
     async def _chunked_upload(self, stream, path):
         """Uploads the given stream to S3 over multiple chunks"""
@@ -1044,7 +1026,6 @@ class S3CompatSigV4Provider(provider.BaseProvider):
         )
 
         contents = await resp.read()
-        logger.info('S3CompatSigV4Provider._metadata_folder: %s', contents)
         parsed = xmltodict.parse(parse.unquote_plus(contents.decode('utf-8')), strip_whitespace=False)['ListBucketResult']
 
         next_token_string = parsed.get('NextMarker', '')

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -842,7 +842,6 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                     'Bucket': self.bucket_name,
                     'Prefix': prefix,
                     'MaxKeys': 1000,
-                    'EncodingType': 'url',
                 }
                 if continuation_token:
                     query_params['ContinuationToken'] = continuation_token
@@ -859,7 +858,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 )
                 contents = await resp.read()
                 parsed = xmltodict.parse(
-                    parse.unquote_plus(contents.decode('utf-8')),
+                    contents.decode('utf-8'),
                     strip_whitespace=False,
                 )['ListBucketResult']
                 objects = parsed.get('Contents', [])
@@ -877,13 +876,15 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 for i in range(0, len(all_objects), 1000):
                     batch = all_objects[i:i + 1000]
                     loop = asyncio.get_event_loop()
-                    await loop.run_in_executor(
+                    response = await loop.run_in_executor(
                         None,
                         lambda d=batch: self.bucket.delete_objects(
-                            Delete={'Objects': d, 'Quiet': True}
+                            Delete={'Objects': d, 'Quiet': False}
                         ),
                     )
                     logger.info('_delete_folder fallback: deleted batch of %d objects', len(batch))
+                    if response.get('Errors'):
+                        logger.error('_delete_folder fallback: delete errors: %s', response['Errors'])
             # Also clean up folder prefix
             try:
                 await self._delete_folder_prefix(prefix)

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -870,6 +870,10 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             deleted_count = len(response.get('Deleted', []))
             logger.debug('Batch deleted %d objects from folder', deleted_count)
 
+        # Clean up folder prefix object if it still exists
+        if await self._folder_prefix_exists(prefix):
+            await self._delete_folder_prefix(prefix)
+
     async def get_full_revision(self, query_params):
         """
         Get all versions and delete markers of the requested object

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -742,6 +742,25 @@ class S3CompatSigV4Provider(provider.BaseProvider):
         else:
             await self._delete_folder(path, **kwargs)
 
+    async def _delete_folder_prefix(self, prefix):
+        """Delete the folder prefix object (e.g. 'foldername/') from S3."""
+        query_parameters = {'Bucket': self.bucket_name, 'Key': prefix}
+        resp = await self.make_request(
+            'DELETE',
+            functools.partial(
+                self.connection.generate_presigned_url,
+                'delete_object',
+                Params=query_parameters,
+                HttpMethod='DELETE',
+            ),
+            expects=(
+                HTTPStatus.OK,
+                HTTPStatus.NO_CONTENT,
+            ),
+            throws=exceptions.DeleteError,
+        )
+        await resp.release()
+
     async def _folder_prefix_exists(self, folder_prefix):
         # Even if the storage is MinIO, Contents with a leaf folder is
         # returned when a last slash of a prefix is removed.
@@ -800,7 +819,8 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             # If versions unsupported, we cannot bulk-delete versions; fall back to NotFound or simple exit
             # For safety, attempt a basic listing check
             if await self._folder_prefix_exists(prefix):
-                # Nothing else to delete (no versions support), just return
+                # Delete the folder prefix object explicitly
+                await self._delete_folder_prefix(prefix)
                 return
             raise
 
@@ -809,16 +829,20 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             raise exceptions.NotFoundError(str(path))
 
         version_map = {}
+        keys_without_version = []
         for item in versions + delete_markers:
             key = item.get('Key')
-            version_id = item.get('VersionId')
-            if not key or not version_id:
+            if not key:
                 continue
-            version_map.setdefault(key, []).append(version_id)
+            version_id = item.get('VersionId')
+            if version_id:
+                version_map.setdefault(key, []).append(version_id)
+            else:
+                keys_without_version.append({'Key': key})
 
         all_objects = [
             {'Key': k, 'VersionId': v} for k, vids in version_map.items() for v in vids
-        ]
+        ] + keys_without_version
         # AWS allows max 1000 objects per delete_objects call
         for i in range(0, len(all_objects), 1000):
             batch = all_objects[i: i + 1000]

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -1123,7 +1123,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             'MaxKeys': 1000,
             'EncodingType': 'url',
         }
-        if next_token is not None:
+        if next_token:
             query_parameters['ContinuationToken'] = next_token
 
         resp = await self.make_request(
@@ -1202,5 +1202,5 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 items.append(S3CompatSigV4FileMetadata(self, content))
 
         if next_token_string:
-            items.append(S3CompatSigV4FolderMetadata(self, {'Key': next_token_string}))
+            items.append(S3CompatSigV4FolderMetadata(self, {'Prefix': next_token_string}))
         return items

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -682,40 +682,63 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                         path.full_path: [
                             v.get('VersionId')
                             for v in full_version_list
-                            if v.get('VersionId')
+                            if v.get('VersionId') and v.get('VersionId') != 'null'
                         ]
                     }
 
                     version_ids = version_dict[path.full_path]
-                    # AWS allows max 1000 objects per delete_objects call
-                    for i in range(0, len(version_ids), 1000):
-                        batch = version_ids[i: i + 1000]
-                        delete_list = [
-                            {'Key': path.full_path, 'VersionId': vid} for vid in batch
-                        ]
-                        # Run synchronous boto3 call in executor to avoid blocking
-                        loop = asyncio.get_event_loop()
-                        response = await loop.run_in_executor(
-                            None,
-                            lambda d=delete_list: self.bucket.delete_objects(
-                                Delete={'Objects': d, 'Quiet': False}
+                    if not version_ids:
+                        # No real version IDs (e.g. MinIO without versioning returns 'null')
+                        # Delete the current object directly without specifying VersionId
+                        query_parameters = {
+                            'Bucket': self.bucket_name,
+                            'Key': path.full_path,
+                        }
+                        resp = await self.make_request(
+                            'DELETE',
+                            functools.partial(
+                                self.connection.generate_presigned_url,
+                                'delete_object',
+                                Params=query_parameters,
+                                HttpMethod='DELETE',
                             ),
+                            expects=(
+                                HTTPStatus.OK,
+                                HTTPStatus.NO_CONTENT,
+                            ),
+                            throws=exceptions.DeleteError,
                         )
-                        # Check for errors in response
-                        if 'Errors' in response and response['Errors']:
-                            error_msgs = [
-                                f'Key={e.get("Key")}, VersionId={e.get("VersionId")}, '
-                                f'Code={e.get("Code")}, Message={e.get("Message")}'
-                                for e in response["Errors"]
+                        await resp.release()
+                    else:
+                        # AWS allows max 1000 objects per delete_objects call
+                        for i in range(0, len(version_ids), 1000):
+                            batch = version_ids[i: i + 1000]
+                            delete_list = [
+                                {'Key': path.full_path, 'VersionId': vid} for vid in batch
                             ]
-                            logger.error(
-                                'Errors deleting objects: %s', '; '.join(error_msgs)
+                            # Run synchronous boto3 call in executor to avoid blocking
+                            loop = asyncio.get_event_loop()
+                            response = await loop.run_in_executor(
+                                None,
+                                lambda d=delete_list: self.bucket.delete_objects(
+                                    Delete={'Objects': d, 'Quiet': False}
+                                ),
                             )
-                            raise exceptions.DeleteError(
-                                f'Failed to delete some objects: {"; ".join(error_msgs[:3])}'
-                            )
-                        deleted_count = len(response.get('Deleted', []))
-                        logger.debug('Batch deleted %d versions', deleted_count)
+                            # Check for errors in response
+                            if 'Errors' in response and response['Errors']:
+                                error_msgs = [
+                                    f'Key={e.get("Key")}, VersionId={e.get("VersionId")}, '
+                                    f'Code={e.get("Code")}, Message={e.get("Message")}'
+                                    for e in response["Errors"]
+                                ]
+                                logger.error(
+                                    'Errors deleting objects: %s', '; '.join(error_msgs)
+                                )
+                                raise exceptions.DeleteError(
+                                    f'Failed to delete some objects: {"; ".join(error_msgs[:3])}'
+                                )
+                            deleted_count = len(response.get('Deleted', []))
+                            logger.debug('Batch deleted %d versions', deleted_count)
                 else:
                     # No versions -> delete current object directly
                     query_parameters = {
@@ -903,7 +926,10 @@ class S3CompatSigV4Provider(provider.BaseProvider):
             if not key:
                 continue
             version_id = item.get('VersionId')
-            if version_id:
+            # MinIO without versioning returns VersionId='null' (string).
+            # Passing VersionId='null' to delete_objects does not actually
+            # delete objects on MinIO, so treat it as no version.
+            if version_id and version_id != 'null':
                 version_map.setdefault(key, []).append(version_id)
             else:
                 keys_without_version.append({'Key': key})

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -1202,5 +1202,5 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 items.append(S3CompatSigV4FileMetadata(self, content))
 
         if next_token_string:
-            items.append(S3CompatSigV4FolderMetadata(self, {'Prefix': next_token_string}))
+            items.append(next_token_string)
         return items

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -834,13 +834,60 @@ class S3CompatSigV4Provider(provider.BaseProvider):
         try:
             parsed, versions, delete_markers = await self.get_full_revision(dict(list_query_params))
         except exceptions.MetadataError:
-            # If versions unsupported, we cannot bulk-delete versions; fall back to NotFound or simple exit
-            # For safety, attempt a basic listing check
-            if await self._folder_prefix_exists(prefix):
-                # Delete the folder prefix object explicitly
+            # Versioning not supported (e.g., MinIO). Fall back to ListObjectsV2.
+            all_objects = []
+            continuation_token = None
+            while True:
+                query_params = {
+                    'Bucket': self.bucket_name,
+                    'Prefix': prefix,
+                    'MaxKeys': 1000,
+                    'EncodingType': 'url',
+                }
+                if continuation_token:
+                    query_params['ContinuationToken'] = continuation_token
+                resp = await self.make_request(
+                    'GET',
+                    functools.partial(
+                        self.connection.generate_presigned_url,
+                        'list_objects_v2',
+                        Params=query_params,
+                        HttpMethod='GET',
+                    ),
+                    expects=(HTTPStatus.OK,),
+                    throws=exceptions.MetadataError,
+                )
+                contents = await resp.read()
+                parsed = xmltodict.parse(
+                    parse.unquote_plus(contents.decode('utf-8')),
+                    strip_whitespace=False,
+                )['ListBucketResult']
+                objects = parsed.get('Contents', [])
+                if isinstance(objects, dict):
+                    objects = [objects]
+                all_objects.extend({'Key': obj['Key']} for obj in objects if obj.get('Key'))
+
+                if parsed.get('IsTruncated') == 'true':
+                    continuation_token = parsed.get('NextContinuationToken')
+                else:
+                    break
+
+            if all_objects:
+                for i in range(0, len(all_objects), 1000):
+                    batch = all_objects[i:i + 1000]
+                    loop = asyncio.get_event_loop()
+                    await loop.run_in_executor(
+                        None,
+                        lambda d=batch: self.bucket.delete_objects(
+                            Delete={'Objects': d, 'Quiet': True}
+                        ),
+                    )
+            # Also clean up folder prefix
+            try:
                 await self._delete_folder_prefix(prefix)
-                return
-            raise
+            except Exception:
+                pass
+            return
 
         if not versions and not delete_markers:
             # No objects/versions -> treat as missing (parity with S3 provider)

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -866,6 +866,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 if isinstance(objects, dict):
                     objects = [objects]
                 all_objects.extend({'Key': obj['Key']} for obj in objects if obj.get('Key'))
+                logger.info('_delete_folder fallback: prefix=%s, found %d objects: %s', prefix, len(all_objects), [o['Key'] for o in all_objects[:10]])
 
                 if parsed.get('IsTruncated') == 'true':
                     continuation_token = parsed.get('NextContinuationToken')
@@ -882,6 +883,7 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                             Delete={'Objects': d, 'Quiet': True}
                         ),
                     )
+                    logger.info('_delete_folder fallback: deleted batch of %d objects', len(batch))
             # Also clean up folder prefix
             try:
                 await self._delete_folder_prefix(prefix)

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -646,8 +646,10 @@ class S3CompatSigV4Provider(provider.BaseProvider):
         # After moving a folder, clean up orphaned folder prefix object at source
         if not src_path.is_file:
             prefix = src_path.full_path.lstrip('/')
-            if await self._folder_prefix_exists(prefix):
+            try:
                 await self._delete_folder_prefix(prefix)
+            except Exception:
+                pass
 
         return result
 

--- a/waterbutler/providers/s3compatsigv4/settings.py
+++ b/waterbutler/providers/s3compatsigv4/settings.py
@@ -1,0 +1,12 @@
+from waterbutler import settings
+
+config = settings.child('S3COMPAT_PROVIDER_CONFIG')
+
+
+TEMP_URL_SECS = int(config.get('TEMP_URL_SECS', 100))
+
+CONTIGUOUS_UPLOAD_SIZE_LIMIT = int(config.get('CONTIGUOUS_UPLOAD_SIZE_LIMIT', 128000000))  # 128 MB
+
+CHUNK_SIZE = int(config.get('CHUNK_SIZE', 64000000))  # 64 MB
+
+CHUNKED_UPLOAD_MAX_ABORT_RETRIES = int(config.get('CHUNKED_UPLOAD_MAX_ABORT_RETRIES', 2))


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/56471
テスト
https://redmine.devops.rcos.nii.ac.jp/issues/58400

## Purpose

AWS Signature Version 4 認証に対応した新しいストレージアドオン「S3 Compatible Storage (SigV4)」を追加します。

## Changes

RDM-osf.io

新規 s3compatsigv4 アドオンの実装

モデル、ビュー、シリアライザー、ルーティング
ユーザー設定・ノード設定テンプレート
機関ストレージ用管理画面の対応
ユニットテスト


日本語翻訳ファイルの追加
Dockerfile およびアドオン設定の更新

RDM-waterbutler

ファイル操作用の s3compatsigv4 プロバイダーを追加

背景
一部のS3互換ストレージサービス（新しいバージョンのMinIOなど）では、Signature Version 4 による認証が必須となっています。既存の s3compat アドオンでは対応できないため、新規アドオンとして実装しました。
テスト



## Side effects

<!-- Any possible side effects? -->

## QA Notes

ユニットテスト実装
MinIO, Sakura, Wasabi のSigV4対応ストレージで動作確認済み

E2Eテスト
https://github.com/RCOSDP/RDM-e2e-test-nb/pull/20
https://redmine.devops.rcos.nii.ac.jp/issues/57800

## Deployment Notes
同時にリリースが必要なプルリクエスト
https://github.com/RCOSDP/RDM-osf.io/pull/673

<!-- Any special configurations for deployment? -->
