### PR TITLE
fix(s3compatsigv4): _metadata_folderのページネーションで継続トークンを文字列として返すよう修正

### DIFF
--- a/tests/providers/s3compatsigv4/test_provider.py
+++ b/tests/providers/s3compatsigv4/test_provider.py
@@ -2130,12 +2130,12 @@ class TestMetadata:
         result = await provider._metadata_folder(path, next_token=token)
 
         assert isinstance(result, list)
-        # 1 CommonPrefixes + 1 Contents + 1 next_token marker = 3 items
+        # 1 CommonPrefixes + 1 Contents + 1 next_token string = 3 items
         assert len(result) == 3
         assert result[0].name == '   photos'
         assert result[1].name == 'my-image.jpg'
-        # Last item is the next_token marker for pagination
-        assert result[2].kind == 'folder'
+        # Last item is the next_token string for pagination
+        assert result[2] == 'token-for-next-page'
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/waterbutler/providers/s3compatsigv4/provider.py
+++ b/waterbutler/providers/s3compatsigv4/provider.py
@@ -1202,5 +1202,5 @@ class S3CompatSigV4Provider(provider.BaseProvider):
                 items.append(S3CompatSigV4FileMetadata(self, content))
 
         if next_token_string:
-            items.append(S3CompatSigV4FolderMetadata(self, {'Prefix': next_token_string}))
+            items.append(next_token_string)
         return items


### PR DESCRIPTION
総合テスト用 #85 のコピー