### PR TITLE
[GRDM-58778, 42706] OneDriveファイル/フォルダ取得処理修正 (metadata 422 and download 401)

### DIFF
--- a/tests/providers/onedrive/test_provider.py
+++ b/tests/providers/onedrive/test_provider.py
@@ -580,9 +580,10 @@ class TestDownload:
         assert response.partial
         content = await response.read()
         assert content == b'te'
+        # The ``@microsoft.graph.downloadUrl`` is pre-authenticated, so the Authorization
+        # header must be dropped to avoid a 401 from some OneDrive hosts.
         assert aiohttpretty.has_call(method='GET', uri=download_url,
                                      headers={'Range': 'bytes=0-1',
-                                              'Authorization': 'bearer wrote harry potter',
                                               'accept-encoding': ''})
 
     @pytest.mark.asyncio
@@ -603,6 +604,11 @@ class TestDownload:
         response = await provider.download(path, revision=revision_fixtures['revision_id'])
         content = await response.read()
         assert content == b'ten of them'
+        # This endpoint is a plain Graph API call (not a pre-authenticated URL), so it
+        # must be sent with the Authorization header.
+        assert aiohttpretty.has_call(method='GET', uri=download_url,
+                                     headers={'Authorization': 'bearer wrote harry potter',
+                                              'accept-encoding': ''})
 
     @pytest.mark.asyncio
     async def test_download_no_such_file(self, provider):

--- a/tests/providers/onedrive/test_provider.py
+++ b/tests/providers/onedrive/test_provider.py
@@ -339,7 +339,8 @@ class TestMetadata:
         path = OneDrivePath('/{}'.format(file_name),
                             _ids=(subfolder_provider_fixtures['root_id'], file_id, ))
 
-        list_url = subfolder_provider._build_drive_url(*path.api_identifier, expand='children')
+        # A file is not a folder, so its metadata must be fetched without ``$expand=children``.
+        list_url = subfolder_provider._build_drive_url(*path.api_identifier)
         aiohttpretty.register_json_uri('GET', list_url, body=file_metadata)
 
         result = await subfolder_provider.metadata(path)
@@ -550,7 +551,7 @@ class TestDownload:
         path = OneDrivePath('/toes.txt', _ids=[download_fixtures['root_id'], file_id])
 
         metadata_response = download_fixtures['file_metadata']
-        metadata_url = provider._build_drive_url('items', file_id, **{'$expand': 'children'})
+        metadata_url = provider._build_drive_url('items', file_id)
         aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_response)
 
         aiohttpretty.register_uri('GET', download_fixtures['file_download_url'],
@@ -568,7 +569,7 @@ class TestDownload:
         path = OneDrivePath('/toes.txt', _ids=[download_fixtures['root_id'], file_id])
 
         metadata_response = download_fixtures['file_metadata']
-        metadata_url = provider._build_drive_url('items', file_id, **{'$expand': 'children'})
+        metadata_url = provider._build_drive_url('items', file_id)
         aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_response)
 
         download_url = download_fixtures['file_download_url']
@@ -629,7 +630,7 @@ class TestDownload:
         path = OneDrivePath('/onenote', _ids=[download_fixtures['root_id'], onenote_id])
 
         metadata_response = download_fixtures['onenote_metadata']
-        metadata_url = provider._build_drive_url('items', onenote_id, **{'$expand': 'children'})
+        metadata_url = provider._build_drive_url('items', onenote_id)
         aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_response)
 
         with pytest.raises(exceptions.UnexportableFileTypeError):
@@ -645,7 +646,7 @@ class TestDownload:
         revisions_url = provider._build_drive_url('items', onenote_id, 'versions')
         aiohttpretty.register_json_uri('GET', revisions_url, body=revision_response)
         metadata_response = download_fixtures['onenote_metadata']
-        metadata_url = provider._build_drive_url('items', onenote_id, **{'$expand': 'children'})
+        metadata_url = provider._build_drive_url('items', onenote_id)
         aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_response)
 
         with pytest.raises(exceptions.UnexportableFileTypeError):

--- a/waterbutler/providers/onedrive/provider.py
+++ b/waterbutler/providers/onedrive/provider.py
@@ -251,7 +251,13 @@ class OneDriveProvider(provider.BaseProvider):
         if path.api_identifier is None:  # TESTME
             raise exceptions.NotFoundError(str(path))
 
-        url = self._build_drive_url(*path.api_identifier, **{'$expand': 'children'})
+        # Only folders support expanding children.  Microsoft Graph seems to have started
+        # returning a 422 (getChildrenOnNonFolder) for ``$expand=children`` on non-folder
+        # items around 2026-03, so request the children expansion for folders only.
+        if path.is_dir:
+            url = self._build_drive_url(*path.api_identifier, **{'$expand': 'children'})
+        else:
+            url = self._build_drive_url(*path.api_identifier)
         logger.debug("metadata url::{}".format(repr(url)))
         resp = await self.make_request(
             'GET',

--- a/waterbutler/providers/onedrive/provider.py
+++ b/waterbutler/providers/onedrive/provider.py
@@ -341,6 +341,11 @@ class OneDriveProvider(provider.BaseProvider):
             raise exceptions.DownloadError('"{}" not found'.format(str(path)), code=404)
 
         download_url = None
+        # The ``@microsoft.graph.downloadUrl`` in a file's metadata is a short-lived,
+        # pre-authenticated URL.  Sending our ``Authorization`` header alongside it makes some
+        # OneDrive hosts respond with a 401, so the header is dropped for those requests.  The
+        # ``/versions/{id}/content`` API endpoint still needs the header, so it is kept there.
+        no_auth_header = True
         if revision:
             # Fix OneDrive Business: download file by revisions
             items = await self._revisions_json(path)
@@ -357,6 +362,7 @@ class OneDriveProvider(provider.BaseProvider):
                         # Previous version: download file via API /drives/{drive-id}/items/{item-id}/versions/{version-id}/content
                         path_segments = (*path.api_identifier, 'versions', revision, 'content')
                         download_url = self._build_drive_url(*path_segments)
+                        no_auth_header = False
                     break
         else:
             metadata = await self.metadata(path, revision=revision)
@@ -375,6 +381,7 @@ class OneDriveProvider(provider.BaseProvider):
             range=range,
             expects=(200, 206),
             headers={'accept-encoding': ''},
+            no_auth_header=no_auth_header,
             # TODO: raise error if download folder including oneNote as zip
             # TODO: raise 401 error download empty file {"response": ""}
             throws=exceptions.DownloadError,


### PR DESCRIPTION
## Ticket

GRDM-58778
GRDM-42706

## Purpose

OneDrive（拡張ストレージ）で接続したファイルを開く/ダウンロードできない問題を修正する。ファイル参照時に Internal Server Error 等が発生しており、以下2つの原因に対処する。

1. metadata 取得時の 422: `metadata()` がファイル（非フォルダ）にも `$expand=children` を付与している。Microsoft Graph が 2026-03 頃から非フォルダへの `$expand=children` を getChildrenOnNonFolder（"Children cannot be listed from an item that is not a folder"）の 422 で返すようになり、ファイル参照が失敗するようになった。 (GRDM-58778)
2. ダウンロード時の 401: 事前認証済みの `@microsoft.graph.downloadUrl` に `Authorization` ヘッダーを重ねて送信しており、一部の OneDrive ホスト（個人アカウント等）が 401 (unauthenticated) を返す。upstream commit ceaf712 と同種の事象。 (GRDM-42706)

## Changes

- `metadata()`: フォルダ（`path.is_dir`）の時のみ `$expand=children` を付与。
- `download()`: 事前認証済み downloadUrl では `no_auth_header=True` で Authorization ヘッダーを送らない。過去版取得の `/versions/{id}/content`（素の Graph API）は Authorization を維持。
- onedrive provider のテストを更新。

## Side effects

None

## QA Notes

- Unit Testを追加し、GitHub Actionsで実行(本PR): 全てGreen
- Docker Composeで起動した開発環境にて、OneDrive App(個人アカウントで発行したOAuth App)を設定し、個人アカウントを連携させた状態で以下を確認
  - ファイル/フォルダの表示(expand=childrenの動作確認)
  - 最新ファイル/過去バージョンのダウンロード(no_auth_headerの動作確認)
- E2E Test Notebookによる回帰テストの実施 https://github.com/RCOSDP/RDM-e2e-test-nb/actions/runs/27657963210 : 全てGreen